### PR TITLE
Fixes #78 - Display module name with warning

### DIFF
--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -161,7 +161,7 @@ function logMissingDeps(dependencies, moduleName, missingDeps) {
 		log(
 			colors.red('Warning:'),
 			'You must install the correct dependencies, please run',
-			colors.cyan('npm i --save-dev', moduleName),
+			colors.cyan('npm i --save-dev ' + moduleName),
 			'from your theme directory.'
 		);
 


### PR DESCRIPTION
Hey @mwilliams2014, I've resent this on top of #78 to adhere to our recently updated [CONTRIBUTING](https://github.com/liferay/liferay-themes-sdk/blob/master/CONTRIBUTING.md) guidelines 😉 