### PR TITLE
Fix post-install for layout generator

### DIFF
--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -130,6 +130,23 @@ var layoutGeneratorPrototype = _.merge(liferayThemeGeneratorPrototype, {
 		}
 	},
 
+	install() {
+		var skipInstall = this.options['skip-install'];
+
+		if (!skipInstall) {
+			this.installDependencies({
+				bower: false,
+				callback() {
+					const gulp = require('gulp');
+					require('liferay-plugin-node-tasks').registerTasks({
+						gulp,
+					});
+					gulp.start('init');
+				},
+			});
+		}
+	},
+
 	_getPrompts() {
 		var instance = this;
 


### PR DESCRIPTION
In testing https://github.com/liferay/liferay-js-themes-toolkit/pull/192 I noticed that our post-install gulp task was bombing out after creating a new layout. I went back and established that the same is happening on current "master", due to this change: https://github.com/liferay/liferay-js-themes-toolkit/pull/173

Testing the previous release (v8.0.0-rc.3) confirms that this was a regression.

The way it used to work was that the post-install would run in the directory of the just-generated layout, and the generated gulpfile in that directory pulls in "liferay-plugin-node-tasks" and runs "init".

In the buggy "master" branch, however, we were instead running "init" from "liferay-js-themes-toolkit" (AKA "liferay-themes-sdk"); that is fine for generated themes, but not for generated theme layouts.

So, the fix here is obvious: run the right gulp task.

This commit is a backport from #192 suitable for application to the current "master" branch. See also this issue which describes what I learned about "liferay-plugin-nodes-tasks" while preparing this fix, plus some next steps.

https://github.com/liferay/liferay-js-themes-toolkit/issues/193

Test plan: `yo ./packages/generator-liferay-theme/generators/layout`