### PR TITLE
Update references to old repository name (v8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# liferay-themes-toolkit
+# liferay-js-themes-toolkit

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"sinon": "^4.4.6"
 	},
 	"private": true,
-	"repository": "https://github.com/liferay/liferay-themes-sdk",
+	"repository": "https://github.com/liferay/liferay-js-themes-toolkit",
 	"scripts": {
 		"ci": "prettier-eslint --list-different '*.{js,json,md}' 'packages/**/*.{js,json,md}' && yarn lint && yarn test",
 		"format": "prettier-eslint --write '*.{js,json,md}' 'packages/**/*.{js,json,md}'",

--- a/packages/generator-liferay-theme/package.json
+++ b/packages/generator-liferay-theme/package.json
@@ -6,7 +6,7 @@
 	"main": "generators/app/index.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/generator-liferay-theme"
 	},
 	"author": {

--- a/packages/liferay-theme-deps-7.0/package.json
+++ b/packages/liferay-theme-deps-7.0/package.json
@@ -7,7 +7,7 @@
 	"license": "ISC",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-deps-7.0"
 	},
 	"dependencies": {

--- a/packages/liferay-theme-deps-7.1/package.json
+++ b/packages/liferay-theme-deps-7.1/package.json
@@ -15,7 +15,7 @@
 	"version": "8.0.0-rc.3",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "liferay-theme-deps-7.1"
 	}
 }

--- a/packages/liferay-theme-deps-7.2/package.json
+++ b/packages/liferay-theme-deps-7.2/package.json
@@ -15,7 +15,7 @@
 	"version": "8.0.0-rc.3",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-deps-7.2"
 	}
 }

--- a/packages/liferay-theme-es2015-hook/package.json
+++ b/packages/liferay-theme-es2015-hook/package.json
@@ -2,7 +2,7 @@
 	"name": "liferay-theme-es2015-hook",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-es2015-hook"
 	},
 	"version": "8.0.0-rc.3",

--- a/packages/liferay-theme-mixins/package.json
+++ b/packages/liferay-theme-mixins/package.json
@@ -21,7 +21,7 @@
 	"name": "liferay-theme-mixins",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-mixins"
 	},
 	"version": "8.0.0-rc.3"

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -70,7 +70,7 @@
 	"name": "liferay-theme-tasks",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-tasks"
 	},
 	"version": "8.0.0-rc.3"


### PR DESCRIPTION
I already did this for v9 in:

https://github.com/liferay/liferay-js-themes-toolkit/pull/187

But as we are going to cut at least one last v8 release, we should rename it there too.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/185