### PR TITLE
Add license headers to files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@ CHANGELOG.md
 
 # Template file, not actually valid JSON.
 /packages/generator-liferay-theme/generators/app/templates/_package.json
+
+# We don't want Prettier to strip the trailing blank line.
+/copyright.js

--- a/copyright.js
+++ b/copyright.js
@@ -4,5 +4,3 @@
  * SPDX-License-Identifier: MIT
  */
 
-// eslint-disable-next-line no-console
-console.log('main.js');

--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const chai = require('chai');
 const chalk = require('chalk');

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/generator-liferay-theme/generators/app/templates/gulpfile.js
+++ b/packages/generator-liferay-theme/generators/app/templates/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var gulp = require('gulp');

--- a/packages/generator-liferay-theme/generators/import/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/import/__tests__/index.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const chai = require('chai');
 const chalk = require('chalk');

--- a/packages/generator-liferay-theme/generators/import/index.js
+++ b/packages/generator-liferay-theme/generators/import/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/generator-liferay-theme/generators/import/templates/gulpfile.js
+++ b/packages/generator-liferay-theme/generators/import/templates/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var gulp = require('gulp');

--- a/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 var chai = require('chai');
 
 chai.use(require('chai-fs'));

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/generator-liferay-theme/generators/layout/templates/gulpfile.js
+++ b/packages/generator-liferay-theme/generators/layout/templates/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var gulp = require('gulp');

--- a/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const chai = require('chai');
 const _ = require('lodash');
 

--- a/packages/generator-liferay-theme/generators/themelet/index.js
+++ b/packages/generator-liferay-theme/generators/themelet/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const path = require('path');

--- a/packages/generator-liferay-theme/gulpfile.js
+++ b/packages/generator-liferay-theme/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var coveralls = require('gulp-coveralls');

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 var _ = require('lodash');
 var chai = require('chai');
 var fs = require('fs');

--- a/packages/generator-liferay-theme/lib/layout_creator.js
+++ b/packages/generator-liferay-theme/lib/layout_creator.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var _ = require('lodash-bindright')(require('lodash'));

--- a/packages/liferay-theme-es2015-hook/index.js
+++ b/packages/liferay-theme-es2015-hook/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 var ConfigGenerator = require('liferay-module-config-generator/lib/config-generator');

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/__tests__/doctor.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/doctor.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const del = require('del');
 const fs = require('fs-extra');
 const os = require('os');

--- a/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const lfrThemeConfig = require('../liferay_theme_config.js');
 const testUtil = require('../../test/util');
 

--- a/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');

--- a/packages/liferay-theme-tasks/lib/__tests__/options.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/options.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const argv = require('minimist')(process.argv.slice(2));
 const path = require('path');
 

--- a/packages/liferay-theme-tasks/lib/__tests__/status.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/status.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const status = require('../../lib/status.js');
 const testUtil = require('../../test/util');
 

--- a/packages/liferay-theme-tasks/lib/__tests__/theme_finder.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/theme_finder.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const path = require('path');
 

--- a/packages/liferay-theme-tasks/lib/__tests__/util.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/util.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const path = require('path');
 
 const testUtil = require('../../test/util');

--- a/packages/liferay-theme-tasks/lib/__tests__/war_deployer.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/war_deployer.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const sinon = require('sinon');
 
 const WarDeployer = require('../war_deployer');

--- a/packages/liferay-theme-tasks/lib/__tests__/watch_socket.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/watch_socket.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const assert = require('assert');
 const del = require('del');

--- a/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
+++ b/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const bourbon = require('node-bourbon');

--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/packages/liferay-theme-tasks/lib/liferay_theme_config.js
+++ b/packages/liferay-theme-tasks/lib/liferay_theme_config.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const fs = require('fs-extra');
 

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');

--- a/packages/liferay-theme-tasks/lib/lookup.js
+++ b/packages/liferay-theme-tasks/lib/lookup.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const lfrThemeConfig = require('./liferay_theme_config');
 
 const DEFAULT_VERSION = '7.1';

--- a/packages/liferay-theme-tasks/lib/lookup/base.js
+++ b/packages/liferay-theme-tasks/lib/lookup/base.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/lookup/dependencies.js
+++ b/packages/liferay-theme-tasks/lib/lookup/dependencies.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 function devDependencies(version) {
 	const dependencies = {
 		gulp: '3.9.1',

--- a/packages/liferay-theme-tasks/lib/lookup/kickstart.js
+++ b/packages/liferay-theme-tasks/lib/lookup/kickstart.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const inquirer = require('inquirer');
 const _ = require('lodash');
 

--- a/packages/liferay-theme-tasks/lib/lookup/template.js
+++ b/packages/liferay-theme-tasks/lib/lookup/template.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const chalk = require('chalk');
 
 function choices(version) {

--- a/packages/liferay-theme-tasks/lib/normalize.js
+++ b/packages/liferay-theme-tasks/lib/normalize.js
@@ -1,4 +1,10 @@
 /**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
  * "Normalize" an HTML template by adding JS-injection placeholders as
  * HTML comments at the end of the template <body>.
  *

--- a/packages/liferay-theme-tasks/lib/options.js
+++ b/packages/liferay-theme-tasks/lib/options.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const minimist = require('minimist');
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const sinon = require('sinon');
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/global_module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/global_module_prompt.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const sinon = require('sinon');
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const inquirer = require('inquirer');
 const path = require('path');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const inquirer = require('inquirer');
 const sinon = require('sinon');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const inquirer = require('inquirer');
 const sinon = require('sinon');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 
 const promptUtil = require('../prompt_util');

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
 const exec = require('child_process').exec;

--- a/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const {exec} = require('child_process');
 const inquirer = require('inquirer');
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const inquirer = require('inquirer');
 

--- a/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const colors = require('ansi-colors');
 const inquirer = require('inquirer');

--- a/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
+++ b/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const os = require('os');
 

--- a/packages/liferay-theme-tasks/lib/status.js
+++ b/packages/liferay-theme-tasks/lib/status.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const colors = require('ansi-colors');
 

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const async = require('async');
 const globby = require('globby');

--- a/packages/liferay-theme-tasks/lib/theme_inspector.js
+++ b/packages/liferay-theme-tasks/lib/theme_inspector.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const path = require('path');
 
 const TEMPLATE_LANG_FTL = 'ftl';

--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/gulp_black_list.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/gulp_black_list.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const through = require('through2');

--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/gulp_css_diff.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/gulp_css_diff.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/replace_patterns.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/replace_patterns.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const ConvertBootstrapCLI = require('convert-bootstrap-2-to-3').constructor;

--- a/packages/liferay-theme-tasks/lib/upgrade/7.0/bootstrap_vars.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.0/bootstrap_vars.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const removed = [
 	'line-height-computed',
 	'padding-base-horizontal',

--- a/packages/liferay-theme-tasks/lib/upgrade/7.0/lexicon_mixins.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.0/lexicon_mixins.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const removed = {
 	'color-placeholder': 'color_placeholder',
 	'select-box-icon': 'select_box_icon',

--- a/packages/liferay-theme-tasks/lib/upgrade/7.0/lexicon_vars.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.0/lexicon_vars.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const removed = [
 	'atlas-theme',
 	'box-shadow-default',

--- a/packages/liferay-theme-tasks/lib/upgrade/7.0/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.0/upgrade.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const path = require('path');
 
 const gulpBlackList = require('../6.2/gulp_black_list.js');

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');

--- a/packages/liferay-theme-tasks/lib/war_deployer.js
+++ b/packages/liferay-theme-tasks/lib/war_deployer.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const EventEmitter = require('events').EventEmitter;
 const _ = require('lodash');
 const colors = require('ansi-colors');

--- a/packages/liferay-theme-tasks/lib/watch_socket.js
+++ b/packages/liferay-theme-tasks/lib/watch_socket.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const del = require('del');
 const GogoShell = require('gogo-shell');

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const fs = require('fs-extra');
 const parseString = require('xml2js').parseString;
 const path = require('path');

--- a/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const del = require('del');
 const fs = require('fs-extra');
 const path = require('path');

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -71,7 +71,7 @@ describe('globally installed theme', () => {
 
 			expect(
 				fs.readFileSync(path.join(srcDir, 'js/main.js')).toString()
-			).toEqual('// kickstart-theme js\n');
+			).toContain('// kickstart-theme js\n');
 
 			expect(
 				fs

--- a/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const testUtil = require('../../test/util');
 
 const initCwd = process.cwd();

--- a/packages/liferay-theme-tasks/tasks/__tests__/watch.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/watch.test.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const del = require('del');
 const fs = require('fs-extra');
 const path = require('path');

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const del = require('del');

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/tasks/deploy.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const fs = require('fs-extra');
 const listStream = require('list-stream');

--- a/packages/liferay-theme-tasks/tasks/extend.js
+++ b/packages/liferay-theme-tasks/tasks/extend.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const ExtendPrompt = require('../lib/prompts/extend_prompt');

--- a/packages/liferay-theme-tasks/tasks/init.js
+++ b/packages/liferay-theme-tasks/tasks/init.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 module.exports = function(options) {

--- a/packages/liferay-theme-tasks/tasks/kickstart.js
+++ b/packages/liferay-theme-tasks/tasks/kickstart.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/tasks/overwrite.js
+++ b/packages/liferay-theme-tasks/tasks/overwrite.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/tasks/status.js
+++ b/packages/liferay-theme-tasks/tasks/status.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const lfrThemeConfig = require('../lib/liferay_theme_config');
 const status = require('../lib/status');
 

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const _ = require('lodash');

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const del = require('del');

--- a/packages/liferay-theme-tasks/test/fixtures/themes/6.2/upgrade-theme/gulpfile.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/6.2/upgrade-theme/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
 const gulp = require('gulp');

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.0/explicit-dependency-theme/custom_src_path/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.0/explicit-dependency-theme/custom_src_path/js/main.js
@@ -1,2 +1,8 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 // eslint-disable-next-line no-console
 console.log('main.js');

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.0/kickstart-theme/src/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.0/kickstart-theme/src/js/main.js
@@ -1,1 +1,7 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 // kickstart-theme js

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const _ = require('lodash');
 const del = require('del');
 const fs = require('fs-extra');

--- a/update-package-versions-config.js
+++ b/update-package-versions-config.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const version = process.argv[3];
 
 module.exports = {


### PR DESCRIPTION
These added by eslint-config-liferay based on the added "copyright.js" file. Just like I did in:

https://github.com/liferay/eslint-config-liferay/pull/26

using "2017" as the copyright year which is deemed the blessed "default" year given that it was the year of the first commit in this repo.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/48