### PR TITLE
Fix "packageVersion is not defined" generator an "All" themelet

### DIFF
--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -317,19 +317,21 @@ module.exports = class extends Generator {
 		const liferayVersion = props.liferayVersion;
 
 		this.appname = props.themeId;
-		this.devDependencies = JSON.stringify(
-			lookup('devDependencies', liferayVersion),
-			null,
-			2
-		)
-			.split(/\n\s*/)
-			.join('\n\t\t')
-			.replace('\t\t}', '\t}');
+		if (liferayVersion !== '*') {
+			this.devDependencies = JSON.stringify(
+				lookup('devDependencies', liferayVersion),
+				null,
+				2
+			)
+				.split(/\n\s*/)
+				.join('\n\t\t')
+				.replace('\t\t}', '\t}');
+		}
 		this.liferayVersion = liferayVersion;
 		this.templateLanguage = props.templateLanguage;
 		this.themeName = props.themeName;
 
-		this._setDefaults(liferayVersion);
+		this._setDefaults();
 
 		this._printWarnings(props);
 
@@ -348,7 +350,7 @@ module.exports = class extends Generator {
 		});
 	}
 
-	_setDefaults(_liferayVersion) {
+	_setDefaults() {
 		_.defaults(this, {
 			templateLanguage: 'ftl',
 		});

--- a/packages/generator-liferay-theme/generators/themelet/index.js
+++ b/packages/generator-liferay-theme/generators/themelet/index.js
@@ -101,10 +101,9 @@ module.exports = class extends Base {
 
 	_promptCallback(props) {
 		if (props.liferayVersion == 'All') {
-			this.liferayVersion = '*';
-		} else {
-			super._promptCallback.call(this, props);
+			props.liferayVersion = '*';
 		}
+		super._promptCallback.call(this, props);
 	}
 
 	_track() {


### PR DESCRIPTION
This is a regression that I most likely introduced in:

https://github.com/liferay/liferay-js-themes-toolkit/pull/195

The v9 version of the same:

https://github.com/liferay/liferay-js-themes-toolkit/pull/187

doesn't have the same bug because it uses a different workaround, but I like the one used in this commit better so I am going to propagate it over there too.

Basically, we can't call `lookup` to get the `devDependencies` when making an "All" versions themelet, and we don't have to anyway, because the generated "package.json" does not have a "devDependencies" property in any case.

Test plan:

- `yarn test`
- `yo ./packages/generator-liferay-theme/generators/themelet`
- `yo ./packages/generator-liferay-theme/generators/import`
- `yo ./packages/generator-liferay-theme/generators/layout`
- `yo ./packages/generator-liferay-theme`