### PR TITLE
Bump version numbers in preparation for first v9 release

### DIFF
--- a/packages/generator-liferay-theme/generators/common/messages.js
+++ b/packages/generator-liferay-theme/generators/common/messages.js
@@ -16,7 +16,7 @@ function getVersionSupportMessage(generatorNamespace) {
 		`\n` +
 		`For older versions of Liferay DXP, please use v8 of the toolkit:\n` +
 		`\n` +
-		`    npm i -g generator-liferay-theme@^8.0.0-rc.3\n` +
+		`    npm i -g generator-liferay-theme@^8.0.0\n` +
 		`    yo ${generatorNamespace}\n`
 	);
 }

--- a/packages/generator-liferay-theme/package.json
+++ b/packages/generator-liferay-theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-liferay-theme",
-	"version": "8.0.0-rc.3",
+	"version": "9.0.0-alpha.0",
 	"description": "Yeoman generator for creating Liferay themes",
 	"license": "MIT",
 	"main": "generators/app/index.js",
@@ -37,7 +37,7 @@
 		"chalk": "^2.4.2",
 		"inquirer": "^0.12.0",
 		"insight": "^0.10.1",
-		"liferay-theme-tasks": "^8.0.0-rc.3",
+		"liferay-theme-tasks": "^9.0.0-alpha.0",
 		"lodash": "^4.17.10",
 		"minimist": "^1.2.0",
 		"yeoman-generator": "^3.2.0",

--- a/packages/liferay-theme-mixins/package.json
+++ b/packages/liferay-theme-mixins/package.json
@@ -23,5 +23,5 @@
 		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-mixins"
 	},
-	"version": "8.0.0-rc.3"
+	"version": "9.0.0-alpha.0"
 }

--- a/packages/liferay-theme-tasks/lib/lookup/dependencies.js
+++ b/packages/liferay-theme-tasks/lib/lookup/dependencies.js
@@ -11,7 +11,7 @@ function devDependencies(version) {
 
 	return {
 		gulp: '3.9.1',
-		'liferay-theme-tasks': '8.0.0-rc.3',
+		'liferay-theme-tasks': '9.0.0-alpha.0',
 		'compass-mixins': '0.12.10',
 
 		// TODO: remove this as it only applied to 7.0, I think

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -70,5 +70,5 @@
 		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-tasks"
 	},
-	"version": "8.0.0-rc.3"
+	"version": "9.0.0-alpha.0"
 }

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.2/base-theme-7-2/package.json
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.2/base-theme-7-2/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"gulp": "3.9.1",
-		"liferay-theme-tasks": "8.0.0-rc.3",
+		"liferay-theme-tasks": "9.0.0-alpha.0",
 		"compass-mixins": "0.12.10",
 		"liferay-frontend-theme-classic-web": "2.0.2",
 		"liferay-frontend-theme-styled": "3.0.13",


### PR DESCRIPTION
We cut the v8.0.0 final release earlier this morning, so we can do two things here:

1. Update the prompt in "common/messages.js" telling people how to install v8 to reference "8.0.0" instead of "8.0.0-rc.3", which was the previous release.
2. Bump the package numbers: note that we aren't actually publishing the release yet, but I think we should bump the numbers in preparation because it is a bit weird to have numbers in "master" that are older than the current release.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/225