### PR TITLE
Update dependencies to point at new snapshots

### DIFF
--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -8,8 +8,7 @@ module.exports = {
 	gulp: '3.9.1',
 	'liferay-theme-tasks': '9.0.0-alpha.0',
 	'compass-mixins': '0.12.10',
-
-	// TODO: update after v4 of these dependencies get cut
-	'liferay-frontend-theme-styled': '3.0.13',
-	'liferay-frontend-theme-unstyled': '3.0.13',
+	'liferay-frontend-common-css': '^1.0.4',
+	'liferay-frontend-theme-styled': '^4.0.0-alpha.1552930087997',
+	'liferay-frontend-theme-unstyled': '^4.0.0-alpha.1552930030671',
 };


### PR DESCRIPTION
These were published just yesterday. They also have an implicit dependency on "liferay-frontend-common-css" so I added that back to the list.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/225