### PR TITLE
Teach liferay-theme:import generator to work with relative paths

### DIFF
--- a/packages/generator-liferay-theme/generators/import/index.js
+++ b/packages/generator-liferay-theme/generators/import/index.js
@@ -29,7 +29,7 @@ module.exports = class extends Base {
 	}
 
 	_writeThemeFiles() {
-		this.sourceRoot(this.importTheme);
+		this.sourceRoot(this.destinationRoot());
 
 		this.fs.copy(
 			this.templatePath('docroot/_diffs'),


### PR DESCRIPTION
Test plan: `yo ./packages/generator-liferay-theme/generators/import` and see it work with each of the following kinds of path:

- `my-theme`
- `./my-theme`
- `/Users/greghurrell/code/liferay-js-themes-toolkit/my-theme`

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/245