### PR TITLE
Fix "gulp upgrade" task for 6.2 themes (#244)

### DIFF
--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -23,6 +23,7 @@
 		"gulp-load-plugins": "^1.5.0",
 		"gulp-plumber": "^0.6.6",
 		"gulp-postcss": "^8.0.0",
+		"gulp-prompt": "^1.2.0",
 		"gulp-rename": "^1.2.0",
 		"gulp-replace-task": "^0.11.0",
 		"gulp-sourcemaps": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,6 +3317,15 @@ gulp-postcss@^8.0.0:
     postcss-load-config "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
+gulp-prompt@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gulp-prompt/-/gulp-prompt-1.2.0.tgz#8f716dd16efc7464f90d9a82fde9dd7e835ee12e"
+  integrity sha512-PVjuGtXNB/RiFOFTwCwiITuF9k5j1no4Bc7bVDKjWT80wNz/SC4lGqGLnm4R8t9bjhkuosBicg+HB/04P0KMzg==
+  dependencies:
+    event-stream "3.3.4"
+    inquirer "^3.3.0"
+    lodash.template "^4.4.0"
+
 gulp-rename@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
@@ -3802,7 +3811,7 @@ inquirer@^0.12.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^3.0.6:
+inquirer@^3.0.6, inquirer@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
@@ -5224,7 +5233,7 @@ lodash._reinterpolate@^2.4.1, lodash._reinterpolate@~2.4.1:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz#4f1227aa5a8711fc632f5b07a1f4607aab8b3222"
   integrity sha1-TxInqlqHEfxjL1sHofRgequLMiI=
 
-lodash._reinterpolate@^3.0.0:
+lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
@@ -5381,6 +5390,14 @@ lodash.template@^3.0.0:
     lodash.restparam "^3.0.0"
     lodash.templatesettings "^3.0.0"
 
+lodash.template@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  integrity sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
 lodash.templatesettings@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5"
@@ -5388,6 +5405,13 @@ lodash.templatesettings@^3.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
 
 lodash.templatesettings@~2.4.1:
   version "2.4.1"


### PR DESCRIPTION
I had mistakenly removed the gulp-prompt dependency in bea3c7035673e80 because I thought it was unused and the old version (0.1.2) was adding noise to the `yarn audit` report.

Turns out it still is used by the 6.2 "upgrade" task, but the usage didn't show up in my search because there is no explicit `require()` call, only dynamic loading via the "gulp-load-plugins" package. (And now that I look at the list of plugins in the theme tasks package.json, I see some others that I suspect may not be used anywhere, but auditing those must be a task for a different commit.)

Here we add it back, but now a much newer version (1.2.0). The `yarn audit` output is unaffected.

Test plan: `gulp upgrade` in a 6.2 theme ([gist](https://gist.github.com/wincent/30a1cad30e6c92b9d9c05a067c019ddc)); `yarn test`.

Builds on: https://github.com/liferay/liferay-js-themes-toolkit/pull/247

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/244