### PR TITLE
Make theme importing work regardless of theme location

### DIFF
--- a/packages/generator-liferay-theme/generators/import/index.js
+++ b/packages/generator-liferay-theme/generators/import/index.js
@@ -24,6 +24,12 @@ module.exports = class extends Base {
 		super.prompting();
 	}
 
+	_enforceFolderName() {
+		this.destinationRoot(path.resolve(this.importTheme));
+
+		this.config.save();
+	}
+
 	configuring() {
 		super.configuring();
 	}


### PR DESCRIPTION
This is a follow-up to #246. We found in testing that relative paths worked inside the current working directory, but a path like "../my-theme" did not. I believe this commit truly makes things work in a path-agnostic way.

Here's what was happening before when you ran the generator:

1. In the "import" generator, `this.appname` would be set to the basename of the supplied theme. In other words, irrespective of whether you passed "./my-theme", "../my-theme", "my-theme" or "/abs/path/my-theme" it would be set to "my-theme".
2. In the "base" class, `_setThemeDirName` would set `this.themeDirName` to "my-theme"; if you had instead passed "my" (and a folder with that name existed on disk) then `themeDirName` would become "my-theme" at that point.
3. In the "base" class, `_enforceFolderName` would check to see whether the current `destinationRoot()` ended with "my-theme", and if it didn't, it would append it; I believe that was broken behavior, because `destinationRoot()` starts off as being the current working directory, which means that we were assuming your theme was in the current working directory even if you supplied us with an absolute path to it.
4. If we set `destinationRoot()` in the manner described above, that ends up changing the `process.cwd()` as a side-effect (if my analysis is correct here, into a non-existent directory, which would normally throw an error).
5. In the "import" generator our `destinationRoot()` is wrong and so is our `sourceRoot()`, because it's the same.

So, the fix then is to override the "3" above. (Note that "2" still executes but doesn't really do anything.) We don't call the superclass method in our override because that would have the unwanted side-effect of changing our working directory and making any subsequent attempt to use `path.resolve` broken. Instead, we just set the `destinationRoot` correctly.

I could also have set the `destinationRoot` first and *then* called the superclass method, but the superclass method isn't doing anything useful for us anyway: all it does is check to see if the dirname matches the root, and we *know* it does at this point because we just set it.

This is all pretty fiddly and fragile, but that's the nature of this style of inheritance.

Test plan: `yarn test` and `yo ./packages/generator-liferay-theme/generators/import` and supply a
bunch of different themes:

- `./a-theme`
- `a-theme`
- `a`
- `/path/to/a-theme`
- `/path/to/a`
- `../a-theme`
- `../a`
- `/path/somewhere-outside-cwd/to/a-theme`

Builds on: https://github.com/liferay/liferay-js-themes-toolkit/pull/249