### PR TITLE
Provide a hint to run "gulp upgrade" before "build" after import

### DIFF
--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -10,11 +10,22 @@ const log = require('fancy-log');
 
 const lfrThemeConfig = require('./liferay_theme_config');
 
-// This array contains all theme versions supported for non-upgrade tasks
-const supportedThemeVersions = ['7.0', '7.1'];
+/* eslint-disable quote-props */
 
-// This array contains all theme versions supported for upgrade tasks
-const supportedUpgradeVersions = ['6.2', '7.0'];
+// Theme version support for upgrade tasks:
+const supportedUpgradeVersions = {
+	'6.2': true,
+	'7.0': true,
+};
+
+// Theme version support for non-upgrade tasks:
+const supportedThemeVersions = {
+	'6.2': ' - please run "gulp upgrade" first',
+	'7.0': true,
+	'7.1': true,
+};
+
+/* eslint-enable quote-props */
 
 function doctor({
 	themeConfig = null,
@@ -70,7 +81,7 @@ function assertTasksSupported(version, tasks) {
 				break;
 
 			case 'upgrade':
-				if (supportedUpgradeVersions.indexOf(version) == -1) {
+				if (supportedUpgradeVersions[version] !== true) {
 					throw new Error(
 						`Task '${task}' is not supported for themes with ` +
 							`version '${version}' in this version of ` +
@@ -80,11 +91,13 @@ function assertTasksSupported(version, tasks) {
 				break;
 
 			default:
-				if (supportedThemeVersions.indexOf(version) == -1) {
+				if (supportedThemeVersions[version] !== true) {
+					const message = supportedThemeVersions[version] || '';
+
 					throw new Error(
 						`Task '${task}' is not supported for themes with ` +
 							`version '${version}' in this version of ` +
-							`'liferay-theme-tasks'`
+							`'liferay-theme-tasks'${message}`
 					);
 				}
 				break;


### PR DESCRIPTION
(This is an unchanged rebase of #247, targeting the "8.x" branch, because I had that one targeting another draft PR and then I forgot to retarget it before merging.)

While trying to reproduce:

https://github.com/liferay/liferay-js-themes-toolkit/issues/244

you can see how if you run the "import" generator to import a 6.2 theme and then run "gulp build" you will see this unfriendly error message:

> Error: Task 'build' is not supported for themes with version '6.2' in
> this version of 'liferay-theme-tasks'

In our docs, we advise people to run "gulp upgrade" first:

https://dev.liferay.com/en/develop/tutorials/-/knowledge_base/7-1/running-the-upgrade-task-for-6-2-themes

But people may not read the docs, so let's improve the error message as well. With this commit, we instead say:

> Error: Task 'build' is not supported for themes with version '6.2'
> in this version of 'liferay-theme-tasks' - please run "gulp upgrade"
> first

Test plan: `yarn test`, and import a 6.2 theme with `yo ./packages/generator-liferay-theme/generators/import`, update the `gulpfile.js` to reference the local copy of the theme tasks (ie. `require('../packages/liferay-theme-tasks')`, then run `gulp build`.

Builds on: https://github.com/liferay/liferay-js-themes-toolkit/pull/246

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/248