### PR TITLE
fix: "import" generator performing in-place imports

### DIFF
--- a/packages/generator-liferay-theme/generators/import/index.js
+++ b/packages/generator-liferay-theme/generators/import/index.js
@@ -24,19 +24,15 @@ module.exports = class extends Base {
 		super.prompting();
 	}
 
-	_enforceFolderName() {
-		this.destinationRoot(path.resolve(this.importTheme));
-
-		this.config.save();
-	}
-
 	configuring() {
+		// Must resolve theme files path before calling super (which chdirs).
+		this.themeFiles = path.resolve(this.importTheme);
+
 		super.configuring();
 	}
 
 	_writeThemeFiles() {
-		// Importing updates the imported theme files in-place.
-		this.sourceRoot(this.destinationRoot());
+		this.sourceRoot(this.themeFiles);
 
 		this.fs.copy(
 			this.templatePath('docroot/_diffs'),
@@ -49,7 +45,10 @@ module.exports = class extends Base {
 	}
 
 	writing() {
+		// Copy files from ../templates:
 		this._writeApp();
+
+		// Copy files from imported theme:
 		this._writeThemeFiles();
 	}
 


### PR DESCRIPTION
In discussing the related ticket it became clear that the new behavior of the tool was not intended: we were performing an in-place update of an imported theme instead of creating a new theme folder in the current directory.

I added some comments to the code to make it clear what is actually happening.

Test plan:

1. With a 6.2 theme one directory above us, do `yo path/to/generator` and supply "../manzanita-theme" as a path. See the new theme get created in the current directory with name "manzanita-theme".
2. With a 7.2 theme one directory below us, do `yo path/to/generator` and supply "/absolute/path/to/manzanita" as a path. See the theme get created in the current directory with name "manzanita-theme" (note that it appended "-theme" even though I had intentionally stripped that suffix from the source directory.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/255