### PR TITLE
feat: Provide hint to update to v9.x in order to upgrade a 7.1 theme

### DIFF
--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -12,20 +12,28 @@ const lfrThemeConfig = require('./liferay_theme_config');
 
 /* eslint-disable quote-props */
 
-// Theme version support for upgrade tasks:
-const supportedUpgradeVersions = {
-	'6.2': true,
-	'7.0': true,
-};
+const SUPPORTED_TASKS = {
+	upgrade: {
+		'6.2': true,
+		'7.0': true,
+		'7.1':
+			' - to upgrade a 7.1 theme please run ' +
+			'"npm install --save-dev liferay-theme-tasks@9.0.0-alpha.1" ' +
+			'and then "gulp upgrade" again',
+	},
 
-// Theme version support for non-upgrade tasks:
-const supportedThemeVersions = {
-	'6.2': ' - please run "gulp upgrade" first',
-	'7.0': true,
-	'7.1': true,
+	default: {
+		'6.2': ' - please run "gulp upgrade" first',
+		'7.0': true,
+		'7.1': true,
+	},
 };
 
 /* eslint-enable quote-props */
+
+function getSupportedTasks(task) {
+	return SUPPORTED_TASKS[task] || SUPPORTED_TASKS.default;
+}
 
 function doctor({
 	themeConfig = null,
@@ -80,25 +88,16 @@ function assertTasksSupported(version, tasks) {
 			case 'init':
 				break;
 
-			case 'upgrade':
-				if (supportedUpgradeVersions[version] !== true) {
-					throw new Error(
-						`Task '${task}' is not supported for themes with ` +
-							`version '${version}' in this version of ` +
-							`'liferay-theme-tasks'`
-					);
-				}
-				break;
-
 			default:
-				if (supportedThemeVersions[version] !== true) {
-					const message = supportedThemeVersions[version] || '';
-
-					throw new Error(
-						`Task '${task}' is not supported for themes with ` +
-							`version '${version}' in this version of ` +
-							`'liferay-theme-tasks'${message}`
-					);
+				{
+					const message = getSupportedTasks(task)[version] || '';
+					if (message !== true) {
+						throw new Error(
+							`Task '${task}' is not supported for themes with ` +
+								`version '${version}' in this version of ` +
+								`'liferay-theme-tasks'${message}`
+						);
+					}
 				}
 				break;
 		}


### PR DESCRIPTION
Test plan:

In a 7.1 theme gulpfile, change the `require` to point at this PR (ie. `require('../packages/liferay-theme-tasks')`.

Then, run `gulp upgrade` in the 7.1 theme and see:

    Error: Task 'upgrade' is not supported for themes with
    version '7.1' in this version of 'liferay-theme-tasks' -
    to upgrade a 7.1 theme please run "npm install --save-dev
    liferay-theme-tasks@9.0.0-alpha.1" and then "gulp upgrade" again

Run `npm install --save-dev liferay-theme-tasks@9.0.0-alpha.1`. Change the `require` back to `require('liferay-theme-tasks')` so that the theme will use the code we just told the user to download, then run `gulp upgrade` again and see it work.

Note that users obviously won't have to edit their gulpfiles; it's only necessary for testing in a dev environment like this one.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/257