### PR TITLE
feat: Make "doctor" tips stand out in a different color

### DIFF
--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -17,7 +17,7 @@ const SUPPORTED_TASKS = {
 		'6.2': true,
 		'7.0': true,
 		'7.1':
-			' - to upgrade a 7.1 theme please run ' +
+			' - please run ' +
 			'"npm install --save-dev liferay-theme-tasks@9.0.0-alpha.1" ' +
 			'and then "gulp upgrade" again',
 	},
@@ -92,11 +92,14 @@ function assertTasksSupported(version, tasks) {
 				{
 					const message = getSupportedTasks(task)[version] || '';
 					if (message !== true) {
-						throw new Error(
-							`Task '${task}' is not supported for themes with ` +
-								`version '${version}' in this version of ` +
-								`'liferay-theme-tasks'${message}`
+						log(
+							colors.yellow(
+								`Task '${task}' is not supported for themes ` +
+									`with version '${version}' in this ` +
+									`version of 'liferay-theme-tasks'${message}`
+							)
 						);
+						throw new Error('Unsupported task');
 					}
 				}
 				break;


### PR DESCRIPTION
As noted in the related issue, in a couple of recent PRs I taught `doctor.js` to provide a helpful hint instead of just blowing up when you try to perform a task that is not supported for a particular theme version. For example you would see a message like:

    Error: Task 'upgrade' is not supported for themes with version '7.1'
    in this version of 'liferay-theme-tasks' - please run
    "npm install --save-dev liferay-theme-tasks@9.0.0-alpha.1"
    and then "gulp upgrade" again

or:

    Error: Task 'build' is not supported for themes with version '6.2'
    in this version of 'liferay-theme-tasks' - please run "gulp upgrade"
    first

Trouble is, this text was easy to miss because it was in the default foreground color and followed by a huge stack trace.

In this commit we instead show it on a separate line, in yellow, and I took the liberty of shortening the tip text a little.

Test plan: Try to upgrade a 7.1 theme with "gulp upgrade" and see:

https://gist.github.com/wincent/3de657c08fe37c7c087957582c40a644

![liferay-js-themes-toolkit___node_modules__bin_gulp](https://user-images.githubusercontent.com/7074/55015949-184cae00-4fee-11e9-9b75-4d8c2333c9a6.png)

As usual, need to update the gulpfile to `require()` my local copy of the theme tasks (ie. `require('../packages/liferay-theme-tasks')`) in order for the test to work.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/262