### PR TITLE
fix: failure to rename css -> scss files during 6.2 -> 7.0 upgrade (#265)

### DIFF
--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
@@ -248,7 +248,7 @@ module.exports = function(options) {
 		const baseFile = ['aui', 'main'];
 
 		const prompts = [];
-		let srcPaths = [];
+		const srcPaths = [];
 
 		_.forEach(fs.readdirSync(path.join(CWD, DIR_SRC_CSS)), function(item) {
 			const fileName = path.basename(item, '.css');
@@ -284,6 +284,7 @@ module.exports = function(options) {
 		});
 
 		let promptResults;
+		const filteredPaths = [];
 
 		gulp.src(srcPaths)
 			.pipe(
@@ -293,9 +294,15 @@ module.exports = function(options) {
 			)
 			.pipe(
 				plugins.filter(function(file) {
-					const fileName = path.basename(file.path);
+					const extname = path.extname(file.path).slice(1);
+					const basename = path.basename(file.path, `.${extname}`);
 
-					return promptResults[fileName];
+					if (promptResults[basename][extname]) {
+						filteredPaths.push(file.path);
+						return true;
+					}
+
+					return false;
 				})
 			)
 			.pipe(
@@ -309,21 +316,7 @@ module.exports = function(options) {
 			)
 			.pipe(gulp.dest(DIR_SRC_CSS))
 			.on('end', function() {
-				srcPaths = _.reduce(
-					srcPaths,
-					function(result, item) {
-						const fileName = path.basename(item);
-
-						if (promptResults[fileName]) {
-							result.push(item);
-						}
-
-						return result;
-					},
-					[]
-				);
-
-				del(srcPaths, cb);
+				del(filteredPaths, cb);
 			});
 	});
 


### PR DESCRIPTION
While trying to repro the related issue I noticed that CSS files in the theme were not getting renamed despite me answering "y" at the prompts.

The cause was a broken test for `promptResults[fileName]`, where `fileName` was something like "custom.css". This doesn't actually match the `promptResults` data structure, which looks like this:

    {
      custom: {
        css: true,
      },
      main: {
        css: false,
      },
    }

(where the `true` and `false` values reflect the answers given at the prompts.)

Test plan:

- `yarn test`
- `yo ./packages/generator-liferay-theme/generators/import`
- Provide path to a 6.2 theme, eg. "./manzanita".
- In the imported theme, edit the gulpfile to `require('../packages/liferay-theme-tasks')` so that we can test this change.
- `gulp upgrade`.
- Answer "y" and "n" at the prompts:

```
? Do you want to rename custom.css to _custom.scss? Yes
? Do you want to rename main.css to main.scss? No
```

- In temporary logging statements that I added, see the first file is renamed and then deleted:

```
rename(): { dirname: '.', basename: 'custom', extname: '.css' }
delete: [ '/Users/greghurrell/code/liferay-js-themes-toolkit/manzanita-theme/src/css/custom.css' ]
```

- In the imported theme, inspect "src/css" and see that the rename took effect.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/265