### PR TITLE
doc: remove stale references to Visual Studio (#271)

### DIFF
--- a/packages/generator-liferay-theme/README.md
+++ b/packages/generator-liferay-theme/README.md
@@ -21,8 +21,6 @@ Note: the generator will create a new folder in your current directory that will
 Some additional steps may be required when using the generator on Windows. We use [node-sass](https://www.npmjs.com/package/node-sass), which requires node-gyp to run, and node-gyp requires Python to be installed. You can read more at the following link:<br>
 [node-gyp Installation](https://github.com/nodejs/node-gyp#installation)<br>
 
-There is one other possible alternative that some may find easier to setup. You can use the ruby based version of Sass. In order to use that version of Sass, you'll need to install Ruby with the [Ruby Installer](http://rubyinstaller.org/), and install the Sass and Compass gems from the command line (`gem install sass compass`), and when the generator asks you if you need Compass support, type "Y". This will bypass node-gyp completely, and use the Ruby versions of Sass and Compass.
-
 ## Generators
 
 Available generators:

--- a/packages/generator-liferay-theme/README.md
+++ b/packages/generator-liferay-theme/README.md
@@ -18,11 +18,8 @@ Note: the generator will create a new folder in your current directory that will
 
 ### Usage on Windows
 
-Unfortunately, there can be some minor headaches when using the generator on Windows.
-The main reason is because, by default, we use [node-sass](https://www.npmjs.com/package/node-sass), which requires node-gyp to run.
-node-gyp requires Python and Visual Studio to be installed. You can read more at the following links:<br>
+Some additional steps may be required when using the generator on Windows. We use [node-sass](https://www.npmjs.com/package/node-sass), which requires node-gyp to run, and node-gyp requires Python to be installed. You can read more at the following link:<br>
 [node-gyp Installation](https://github.com/nodejs/node-gyp#installation)<br>
-[Visual Studio Setup](https://github.com/nodejs/node-gyp/wiki/Visual-Studio-2010-Setup)
 
 There is one other possible alternative that some may find easier to setup. You can use the ruby based version of Sass. In order to use that version of Sass, you'll need to install Ruby with the [Ruby Installer](http://rubyinstaller.org/), and install the Sass and Compass gems from the command line (`gem install sass compass`), and when the generator asks you if you need Compass support, type "Y". This will bypass node-gyp completely, and use the Ruby versions of Sass and Compass.
 


### PR DESCRIPTION
Apparently, Visual Studio is no longer required, just node-gyp (and therefore Python). I removed the references, and also removed some of the regretful emotional wording in favor of a more neutral register.

This is the 8.x cherry-pick of https://github.com/liferay/liferay-js-themes-toolkit/pull/272 with one additional commit on top.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/271