### PR TITLE
fix: make it harder to accidentally produce duplicate entries in changelog

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -508,10 +508,19 @@ async function main(_node, _script, ...args) {
 		}
 
 		if (previousContents.indexOf(`[${version}]`) !== -1) {
-			warn(
+			const message = [
 				`${outfile} already contains a reference to ${version}.`,
 				'Did you mean to regenerate using the --regenerate switch?'
-			);
+			];
+			if (options.force) {
+				warn(...message);
+			} else {
+				error(
+					...message,
+					'Alternatively, proceed anyway by using the --force switch.'
+				);
+				process.exit(1);
+			}
 		}
 
 		const newContents = [contents, previousContents]

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -510,7 +510,7 @@ async function main(_node, _script, ...args) {
 		if (previousContents.indexOf(`[${version}]`) !== -1) {
 			const message = [
 				`${outfile} already contains a reference to ${version}.`,
-				'Did you mean to regenerate using the --regenerate switch?'
+				'Did you mean to regenerate using the --regenerate switch?',
 			];
 			if (options.force) {
 				warn(...message);

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -163,7 +163,7 @@ async function getRemote(options) {
 
 	for (let i = 0; i < lines.length; i++) {
 		const match = lines[i].match(
-			/\bgithub\.com\/liferay\/(\S+?)(?:\.git)?\s/i
+			/\bgithub\.com[/:]liferay\/(\S+?)(?:\.git)?\s/i
 		);
 		if (match) {
 			return `https://github.com/liferay/${match[1]}`;


### PR DESCRIPTION
Two things:

- Make sure we autodetect `git@github.com` remotes, which means we'll be less likely to run the command twice in a row (once without and once with the `--remote` switch).
- Make the "already contains reference to $VERSION" warning into a hard error, unless running with `--force`.