### PR TITLE
feat: print watch info when starting watch (v8.x) (#277)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const chalk = require('chalk');
 const del = require('del');
 const fs = require('fs');
 const http = require('http');
@@ -223,7 +224,22 @@ module.exports = function(options) {
 				});
 			}
 		}).listen(httpPort, function() {
-			opn(`http://localhost:${httpPort}/`);
+			const url = `http://localhost:${httpPort}/`;
+			const messages = [
+				`Watch mode is now active at: ${url}`,
+				`Proxying: ${proxyUrl}`,
+			];
+			const width = messages.reduce((max, line) => {
+				return Math.max(line.length, max);
+			}, 0);
+			const ruler = '-'.repeat(width);
+
+			// eslint-disable-next-line no-console
+			console.log(
+				'\n' + chalk.yellow([ruler, ...messages, ruler].join('\n'))
+			);
+
+			opn(url);
 		});
 
 		gulp.watch(path.join(pathSrc, '**/*'), function(vinyl) {


### PR DESCRIPTION
This is the v8.x cherry-pick of:

https://github.com/liferay/liferay-js-themes-toolkit/pull/278

We used to print something like:

```
[Browsersync] Proxying: http://localhost:8080
[Browsersync] Access URLs:
 ---------------------------------
    Local: http://localhost:9080
 External: http://192.168.2.3:9080
```

when you started watch mode. Now we print pretty much nothing, just some Gulp output ending with:

```
[10:09:22] Starting 'watch:setup'...
[10:09:23] Finished 'watch:setup' after 686 ms
```

While it's true that we do open a browser window pointing at the right port, we should probably also log the URL to the console.

Test plan: Run `gulp watch` and see:

```
[11:00:18] Finished 'build' after 4.31 s
[11:00:18] Starting 'watch:clean'...
[11:00:19] Finished 'watch:clean' after 239 ms
[11:00:19] Starting 'watch:setup'...
[11:00:19] Finished 'watch:setup' after 710 ms

---------------------------------------------------
Watch mode is now active at: http://localhost:9080/
Proxying: http://localhost:8080
---------------------------------------------------
```

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/277