### PR TITLE
chore: Update references to "DXP" in user-facing messages (9.x) (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Breaking changes:**
 
-- Version 9 is a streamlined and modernized toolkit, focusing exclusively on generating themes, layouts and themelets for Liferay DXP 7.2. At the same time, we just released [version 8.0.0 of the toolkit](https://github.com/liferay/liferay-js-themes-toolkit/releases/tag/v8.0.0) that provides tools for working with Liferay DXP 7.0 and 7.1 (#184).
+- Version 9 is a streamlined and modernized toolkit, focusing exclusively on generating themes, layouts and themelets for Liferay DXP and Portal CE 7.2. At the same time, we just released [version 8.0.0 of the toolkit](https://github.com/liferay/liferay-js-themes-toolkit/releases/tag/v8.0.0) that provides tools for working with Liferay DXP and Portal CE versions 7.0 and 7.1 (#184).
 
 **Other changes:**
 
@@ -45,7 +45,7 @@
 - Retire doctor [\#196](https://github.com/liferay/liferay-js-themes-toolkit/issues/196)
 - Fold liferay-plugin-node-tasks into liferay-theme-tasks [\#193](https://github.com/liferay/liferay-js-themes-toolkit/issues/193)
 - Rename to liferay-js-themes-toolkit [\#185](https://github.com/liferay/liferay-js-themes-toolkit/issues/185)
-- Clarify "compatibility matrix" between versions of liferay-js-themes-toolkit and Liferay DXP [\#184](https://github.com/liferay/liferay-js-themes-toolkit/issues/184)
+- Clarify "compatibility matrix" between versions of liferay-js-themes-toolkit and Liferay DXP and Portal CE [\#184](https://github.com/liferay/liferay-js-themes-toolkit/issues/184)
 - Add LICENSE.md files [\#169](https://github.com/liferay/liferay-js-themes-toolkit/issues/169)
 - \[RFC\] Eliminate liferay-theme-deps-\* packages [\#168](https://github.com/liferay/liferay-js-themes-toolkit/issues/168)
 - Fold liferay-theme-finder package into main SDK package [\#166](https://github.com/liferay/liferay-js-themes-toolkit/issues/166)
@@ -75,7 +75,7 @@
 - Update template paths [\#210](https://github.com/liferay/liferay-js-themes-toolkit/pull/210) ([julien](https://github.com/julien))
 - Send correct MIME type \(Content-Type\) header for local css files [\#209](https://github.com/liferay/liferay-js-themes-toolkit/pull/209) ([julien](https://github.com/julien))
 - Fix "packageVersion is not defined" generator an "All" themelet [\#207](https://github.com/liferay/liferay-js-themes-toolkit/pull/207) ([wincent](https://github.com/wincent))
-- Remove incomplete DXP 7.2 support from v8 of toolkit [\#206](https://github.com/liferay/liferay-js-themes-toolkit/pull/206) ([wincent](https://github.com/wincent))
+- Remove incomplete DXP and Portal CE 7.2 support from v8 of toolkit [\#206](https://github.com/liferay/liferay-js-themes-toolkit/pull/206) ([wincent](https://github.com/wincent))
 - Add license headers to files [\#203](https://github.com/liferay/liferay-js-themes-toolkit/pull/203) ([wincent](https://github.com/wincent))
 - Add LICENSE.md files [\#202](https://github.com/liferay/liferay-js-themes-toolkit/pull/202) ([wincent](https://github.com/wincent))
 - Apply clean-up to new "watch" implementation [\#201](https://github.com/liferay/liferay-js-themes-toolkit/pull/201) ([julien](https://github.com/julien))

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ This repo contains the source for a [set of NPM packages](https://github.com/lif
 
 ## Compatibility
 
-Starting with version 9 of the toolkit, in order to keep the toolkit simple, each major version of the toolkit focuses on supporting a specific version of Liferay DXP.
+Starting with version 9 of the toolkit, in order to keep the toolkit simple, each major version of the toolkit focuses on supporting specific versions of Liferay DXP and Portal CE.
 
-| Capability                                         | Required toolkit version |
-| -------------------------------------------------- | ------------------------ |
-| Import a Liferay 6.2 theme                         | v8.x                     |
-| Create themes for Liferay DXP 7.0                  | v8.x                     |
-| Create themes for Liferay DXP 7.1                  | v8.x                     |
-| Upgrade a theme for Liferay 6.2 to Liferay DXP 7.0 | v8.x                     |
-| Upgrade a theme for Liferay DXP 7.0 to 7.1         | v8.x                     |
-| Run tasks using Gulp v3                            | v8.x                     |
-| Create themes for Liferay DXP 7.2                  | v9.x                     |
-| Upgrade a theme for Liferay DXP 7.1 to 7.2         | v9.x                     |
-| Run tasks using Gulp v4                            | v9.x                     |
+| Capability                     | Required toolkit version |
+| ------------------------------ | ------------------------ |
+| Import a 6.2 theme             | v8.x                     |
+| Create themes for 7.0          | v8.x                     |
+| Create themes for 7.1          | v8.x                     |
+| Upgrade a theme for 6.2 to 7.0 | v8.x                     |
+| Upgrade a theme for 7.0 to 7.1 | v8.x                     |
+| Run tasks using Gulp v3        | v8.x                     |
+| Create themes for 7.2          | v9.x                     |
+| Upgrade a theme for 7.1 to 7.2 | v9.x                     |

--- a/packages/generator-liferay-theme/generators/common/messages.js
+++ b/packages/generator-liferay-theme/generators/common/messages.js
@@ -8,13 +8,13 @@ const chalk = require('chalk');
 const version = require('../../package.json').version;
 
 function getVersionSupportMessage(generatorNamespace) {
-	const supportedVersion = chalk.red('Liferay DXP v7.2');
+	const supportedVersion = chalk.red('Liferay DXP and Portal CE v7.2');
 
 	return (
 		`This version of the liferay-js-themes-toolkit (${version})\n` +
 		`can create a ${generatorNamespace} for ${supportedVersion}\n` +
 		`\n` +
-		`For older versions of Liferay DXP, please use v8 of the toolkit:\n` +
+		`For older versions, please use v8 of the toolkit:\n` +
 		`\n` +
 		`    npm i -g generator-liferay-theme@^8.0.0\n` +
 		`    yo ${generatorNamespace}\n`


### PR DESCRIPTION
Updates the references in the README and CHANGELOG just like we did for 8.x in: https://github.com/liferay/liferay-js-themes-toolkit/pull/282

Additionally, there is a change in the generator output, which is what led us to create this issue in the first place. (cc: @mwilliams2014).

Test plan: `yarn test` and run the generator with `yo ./packages/generator-liferay-theme` and see:

    This version of the liferay-js-themes-toolkit (9.0.0-alpha.1)
    can create a liferay-theme for Liferay DXP and Portal CE v7.2

    For older versions, please use v8 of the toolkit:

        npm i -g generator-liferay-theme@^8.0.0
        yo liferay-theme

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/280