### PR TITLE
chore: remove backup/revert functionality (9.x) (#267)

### DIFF
--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -64,33 +64,3 @@ describe('config', () => {
 		});
 	});
 });
-
-describe('create backup files', () => {
-	let runSequence;
-	let tempPath;
-
-	beforeEach(() => {
-		const config = testUtil.copyTempTheme({
-			namespace: 'upgrade_task_create_backup_files',
-			themeName: 'base-theme',
-			registerTasksOptions: {},
-		});
-
-		runSequence = config.runSequence;
-		tempPath = config.tempPath;
-	});
-
-	it('upgrade:create-backup-files should create backup files from source', done => {
-		runSequence('upgrade:create-backup-files', err => {
-			if (err) throw err;
-
-			expect(path.join(tempPath, '_backup')).toBeFolder();
-			expect(path.join(tempPath, '_backup/src')).toBeFolder();
-			expect(
-				path.join(tempPath, '_backup/src/css/_custom.scss')
-			).toBeFile();
-
-			done();
-		});
-	});
-});

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -8,12 +8,10 @@
 
 const _ = require('lodash');
 const colors = require('ansi-colors');
-const del = require('del');
 const fs = require('fs-extra');
 const inquirer = require('inquirer');
 const log = require('fancy-log');
 const path = require('path');
-const plugins = require('gulp-load-plugins')();
 const PluginError = require('plugin-error');
 
 const lfrThemeConfig = require('../lib/liferay_theme_config.js');
@@ -22,11 +20,7 @@ const themeConfig = lfrThemeConfig.getConfig();
 
 module.exports = function(options) {
 	const gulp = options.gulp;
-
-	const runSequence = require('run-sequence').use(gulp);
-
 	const argv = options.argv;
-	const pathSrc = options.pathSrc;
 
 	let version = argv.v || argv.version;
 
@@ -47,21 +41,33 @@ module.exports = function(options) {
 
 	gulp.task('upgrade', function(cb) {
 		if (_.isFunction(versionUpgradeTask)) {
-			runSequence('upgrade:create-backup-files', function() {
-				versionUpgradeTask(function(err) {
-					if (err) {
-						log(
-							colors.red('Error:'),
-							'something went wrong during the upgrade task, reverting changes.'
-						);
-						log(err);
-
-						runSequence('upgrade:revert-src', cb);
+			inquirer.prompt(
+				{
+					default: false,
+					message:
+						'We recommend creating a backup of your theme files before proceeding. ' +
+						'Are you sure you wish to start the upgrade process?',
+					name: 'sure',
+					type: 'confirm',
+				},
+				function(answers) {
+					if (answers.sure) {
+						versionUpgradeTask(function(err) {
+							if (err) {
+								log(
+									colors.red('Error:'),
+									'something went wrong during the upgrade task - ' +
+										'leaving the theme files in place for inspection.'
+								);
+								log(err);
+							}
+							cb();
+						});
 					} else {
 						cb();
 					}
-				});
-			});
+				}
+			);
 		} else {
 			throw new PluginError(
 				'gulp-theme-upgrader',
@@ -70,87 +76,5 @@ module.exports = function(options) {
 				)
 			);
 		}
-	});
-
-	gulp.task('upgrade:create-backup-files', function(cb) {
-		const backupExists = fs.existsSync('_backup');
-
-		const backup = function() {
-			gulp.src(path.join(pathSrc, '**/*'))
-				.pipe(gulp.dest('_backup/src'))
-				.on('end', function() {
-					gulp.src('package.json')
-						.pipe(plugins.rename('_package.json'))
-						.pipe(gulp.dest('_backup'))
-						.on('end', cb);
-				});
-		};
-
-		if (backupExists) {
-			inquirer.prompt(
-				{
-					default: false,
-					message:
-						"Would you like to overwrite the existing _backup directory and it's contents?",
-					name: 'backup',
-					type: 'confirm',
-				},
-				function(answers) {
-					if (answers.backup) {
-						backup();
-					} else {
-						cb();
-					}
-				}
-			);
-		} else {
-			backup();
-		}
-	});
-
-	gulp.task('upgrade:revert', function(cb) {
-		const backupExists =
-			fs.existsSync('_backup/src') &&
-			fs.statSync('_backup/src').isDirectory();
-
-		if (!backupExists) {
-			throw new PluginError(
-				'gulp-theme-upgrader',
-				colors.red('No backup files found!')
-			);
-		}
-
-		inquirer.prompt(
-			[
-				{
-					message:
-						'Are you sure you want to revert src files? This will replace the files in your src directory and your package.json file with those from the _backup directory.',
-					name: 'revert',
-					type: 'confirm',
-				},
-			],
-			function(answers) {
-				if (answers.revert) {
-					runSequence('upgrade:revert-src', cb);
-				} else {
-					log(colors.cyan('No files reverted.'));
-
-					cb();
-				}
-			}
-		);
-	});
-
-	gulp.task('upgrade:revert-src', function(cb) {
-		del.sync(path.join(pathSrc, '**/*'));
-
-		gulp.src('_backup/src/**/*')
-			.pipe(gulp.dest(pathSrc))
-			.on('end', function() {
-				gulp.src('_backup/_package.json')
-					.pipe(plugins.rename('package.json'))
-					.pipe(gulp.dest(process.cwd()))
-					.on('end', cb);
-			});
 	});
 };


### PR DESCRIPTION
We have functionality that creates a backup of files before attempting an upgrade and then offer a revert functionality in the case that an error is thrown.

In practice, this isn't as good as proper version control because:

- You cannot "double revert" because we only make a backup of the most recent change.
- In the event that an upgrade fails we blow away the upgraded files by doing an automatic revert, preventing the user from inspecting them.
- We incur complexity in the codebase, opening the door to bugs.
- We can't provide a very nice upgrade-and-revert experience moving from 6.2 to 7.0 to 7.1 to 7.2 and back because those moves involve switching versions of the toolkit from v8 to v9 along the way, as described in #267.

So this commit removes the backup and revert functionality and instead shows a prompt that advises people to make a backup before upgrading, and confirming their intent to proceed: in practice, I expect that developers using the toolkit will all have their code in Git or an equivalent version control system, so they *already* will have a backup.

If an error occurs, we now show a message stating that the upgraded theme files have been left in place for inspection.

Test plan:

    # Use the generator to create a new 7.1 theme:
    npm install generator-liferay-theme
    yo ./node_modules/generator-liferay-theme

    # Update the `require('liferay-theme-tasks')` in the theme gulpfile
    # to point at the version of the code that I am testing
    cd my-liferay-theme
    edit gulpfile

    # Run the upgrade:
    gulp upgrade

See:

    [17:16:33] Starting 'upgrade'...
    ? We recommend creating a backup of your theme files before proceeding. Are you sure you wish to start the upgrade proc
    ess? No
    [17:16:43] Finished 'upgrade' after 10 s

Run it again and say "y" this time; see:

    [17:16:58] Starting 'upgrade'...
    ? We recommend creating a backup of your theme files before proceeding. Are you sure you wish to start the upgrade proc
    ess? Yes
    [17:16:59] Starting 'upgrade:config'...
    [17:16:59] Finished 'upgrade:config' after 24 ms
    [17:16:59] Starting 'upgrade:dependencies'...
    [17:17:16] Finished 'upgrade:dependencies' after 17 s
    [17:17:16] Finished 'upgrade' after 18 s

Now hardcode the upgrade task to throw an error and see:

    [17:21:19] Finished 'upgrade:dependencies' after 7.4 s
    [17:21:19] Error: something went wrong during the upgrade task, leaving the theme files in place for inspection.
    [17:21:19] Error: Something blew up!

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/267