### PR TITLE
fix: silent failures when using autoprefixer (9.x) (#274)

### DIFF
--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -20,7 +20,6 @@
 		"gulp-liferay-r2-css": "^0.0.2",
 		"gulp-livereload": "^4.0.1",
 		"gulp-load-plugins": "^1.5.0",
-		"gulp-plumber": "^0.6.6",
 		"gulp-postcss": "^8.0.0",
 		"gulp-rename": "^1.2.0",
 		"gulp-replace-task": "^0.11.0",

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -252,7 +252,6 @@ module.exports = function(options) {
 					suffix: '_rtl',
 				})
 			)
-			.pipe(plugins.plumber())
 			.pipe(r2())
 			.pipe(gulp.dest(pathBuild + '/css'));
 	});

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -68,7 +68,6 @@ module.exports = function(options) {
 		const srcPath = path.join(cssBuild, '!(_)*.scss');
 
 		gulp.src(srcPath)
-			.pipe(plugins.plumber())
 			.pipe(gulpIf(sassOptions.sourceMap, gulpSourceMaps.init()))
 			.pipe(gulpSass(sassOptions))
 			.pipe(

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -8,7 +8,6 @@
 
 const _ = require('lodash');
 const path = require('path');
-const plugins = require('gulp-load-plugins')();
 const log = require('fancy-log');
 const postcss = require('gulp-postcss');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,14 +3150,6 @@ gulp-mocha@^2.2.0:
     temp "^0.8.3"
     through "^2.3.4"
 
-gulp-plumber@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/gulp-plumber/-/gulp-plumber-0.6.6.tgz#9f9846a513c70d03216ce7a2a8ce6fd5a3fc3175"
-  integrity sha1-n5hGpRPHDQMhbOeiqM5v1aP8MXU=
-  dependencies:
-    gulp-util "~3"
-    through2 "~0.6"
-
 gulp-postcss@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/gulp-postcss/-/gulp-postcss-8.0.0.tgz#8d3772cd4d27bca55ec8cb4c8e576e3bde4dc550"
@@ -3229,7 +3221,7 @@ gulp-util@^2.2.20:
     through2 "^0.5.0"
     vinyl "^0.2.1"
 
-gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.4, gulp-util@^3.0.7, gulp-util@~3:
+gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.4, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -7720,7 +7712,7 @@ through2@^0.5.0:
     readable-stream "~1.0.17"
     xtend "~3.0.0"
 
-through2@^0.6.1, through2@^0.6.3, through2@~0.6:
+through2@^0.6.1, through2@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=


### PR DESCRIPTION
When deploying a theme using this config in the package.json:

    "liferayTheme": {
            "baseTheme": "styled",
            "distName": "fjord-theme",
            "rubySass": false,
            "version": "7.1",
            "postcss": [
                    "autoprefixer"
            ]
    },

the deploy would silently fail because "gulp-plumber" would swallow the error. If I am reading this background material on plumber correctly:

- https://github.com/floatdrop/gulp-plumber
- https://github.com/gulpjs/gulp/issues/91
- https://gist.github.com/floatdrop/8269868

the intent of the plug-in is to monkey patch the Gulp pipe objects such that an error in one file won't prevent the others from being processed. We added it in this repo in commit 9200922420ee2c290c7d8f658551 (Jan 2016, "Use gulp-plumber for r2 task so that sass-parse errors don't abort build process").

In practice, its black magic is causing deploys to fail inscrutably, so we're dropping it. In the event of an error, let's fail fast instead. And note, in this concrete instance, I don't think there was even an error being thrown in the autoprefixer build at all (based on my `console.log()`-ing around to see at what point it was going off the rails; the postcss run is finishing just fine.

Note that we could also switch our old v0.6.6 version of this dependency to the latest, v1.2.1, but there's nothing in the diff that stands out as being likely to fix this issue, and I'll be much happier if we can jettison this complexity:

https://github.com/floatdrop/gulp-plumber/compare/v0.6.6...v1.2.1

Test plan: In portal, in modules/apps/frontend-theme-fjord/frontend-theme-fjord, turn on autoprefixer with the config mentioned above. Run both `gradlew clean deploy` and also (the equivalent):

```
yarn run gulp deploy \
  --css-common-path ./build_gradle/frontend-css-common \
  --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled \
  --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled
```

and see the build output continue past the "autoprefixer" lines to finish with:

```
[13:21:39] Finished 'deploy' after 5.27 s
✨  Done in 5.97s.
```

Likewise, see the deployment reflected in the server log:

```
1 theme for fjord-theme is available for use
```

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/274