### PR TITLE
feat: add ability to config PostCSS plug-ins (9.x) (#126)

### DIFF
--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -12,7 +12,6 @@ const es = require('event-stream');
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const path = require('path');
-const resolve = require('resolve');
 const tar = require('tar-fs');
 
 const CUSTOM_DEP_PATH_ENV_VARIABLE_MAP = {
@@ -137,13 +136,7 @@ function resolveDependency(dependency) {
 		return customPath;
 	}
 
-	const depsPath = process.cwd();
-
-	const dependencyPath = resolve.sync(dependency, {
-		basedir: depsPath,
-	});
-
-	return path.dirname(require.resolve(dependencyPath));
+	return path.dirname(require.resolve(dependency, {paths: [process.cwd()]}));
 }
 
 function getCustomDependencyPath(dependency) {

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -39,7 +39,6 @@
 		"package-json": "^5.0.0",
 		"plugin-error": "^1.0.1",
 		"portfinder": "^1.0.20",
-		"resolve": "^1.1.7",
 		"run-sequence": "^2.2.1",
 		"tar-fs": "^1.16.3",
 		"through2": "^2.0.0",

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -132,14 +132,7 @@ function getPostCSSOptions(config) {
 
 		postCSSOptions.enabled = true;
 
-		// We bundle autoprefixer automatically, so do not try to
-		// resolve it to the theme
 		postCSSOptions.plugins = config
-			.map(pluginName =>
-				pluginName === 'autoprefixer'
-					? pluginName
-					: themeUtil.resolveDependency(pluginName)
-			)
 			.map(pluginDependency => require(pluginDependency));
 	} else if (rc) {
 		postCSSOptions.enabled = true;

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -132,8 +132,9 @@ function getPostCSSOptions(config) {
 
 		postCSSOptions.enabled = true;
 
-		postCSSOptions.plugins = config
-			.map(pluginDependency => require(pluginDependency));
+		postCSSOptions.plugins = config.map(pluginDependency =>
+			require(pluginDependency)
+		);
 	} else if (rc) {
 		postCSSOptions.enabled = true;
 	}

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const log = require('fancy-log');
@@ -83,15 +84,56 @@ function concatBourbonIncludePaths(includePaths) {
 	return includePaths.concat(createBourbonFile());
 }
 
+/**
+ * Returns the string `file` if a file with that name exists, and
+ * `false` otherwise.
+ *
+ * Example:
+ *
+ *     > exists('package.json')
+ *     'package.json'
+ */
+function exists(file) {
+	return fs.existsSync(file) && file;
+}
+
+/**
+ * Returns a string indicating which of the standard methods for
+ * configuring PostCSS applies to the current theme, if any. Otherwise,
+ * returns `false`.
+ */
+function getPostCSSRC() {
+	const themeConfig = lfrThemeConfig.getConfig(true);
+	return (
+		(themeConfig.hasOwnProperty('postcss') && 'package.json "postcss"') ||
+		exists('.postcssrc') ||
+		exists('.postcssrc.js') ||
+		exists('.postcssrc.json') ||
+		exists('.postcssrc.yml') ||
+		exists('postcss.config.js')
+	);
+}
+
 function getPostCSSOptions(config) {
 	const postCSSOptions = {
 		enabled: false,
 	};
 
-	// We bundle autoprefixer automatically, so do not try to resolve it to the theme
+	const rc = getPostCSSRC();
 
 	if (_.isArray(config) && config.length > 0) {
+		if (rc) {
+			throw new Error(
+				'PostCSS must be configured in only one place but it was ' +
+					'configured in both "liferayTheme" properties of the ' +
+					`package.json and also in ${rc}`
+			);
+		}
+
 		postCSSOptions.enabled = true;
+
+		// We bundle autoprefixer automatically, so do not try to
+		// resolve it to the theme
 		postCSSOptions.plugins = config
 			.map(pluginName =>
 				pluginName === 'autoprefixer'
@@ -99,6 +141,8 @@ function getPostCSSOptions(config) {
 					: themeUtil.resolveDependency(pluginName)
 			)
 			.map(pluginDependency => require(pluginDependency));
+	} else if (rc) {
+		postCSSOptions.enabled = true;
 	}
 
 	return postCSSOptions;


### PR DESCRIPTION
Prior to this commit, we would look at the plugins named in the theme's "package.json" file under "liferayTheme" -> "postcss" and load them. "autoprefixer" was whitelisted because we bundle it with liferay-theme-tasks (ie. we would just do `require('autoprefixer')`).

For the others we would go through our `resolveDependency` helper, which actually seems to be a pointless in the context of PostCSS. I'm going to remove that special casing in the next commit, in order to make it easier to review.

With this commit, we allow for configuration by any of the mechanisms supported by postcss-load-config:

https://www.npmjs.com/package/postcss-load-config

(gulp-postcss will use postcss-load-config transparently behind the scenes).

What this means is that you can add a "postcss" property to you "package.json" like this:

```
	"postcss": {
		"plugins": {
			"autoprefixer": {
				"grid": "autoplace"
			}
		}
	},
```

or, you can create one of:

- .postcssrc
- .postcssrc.js
- .postcssrc.json
- .postcssrc.yml
- postcss.config.js

If you try to supply a PostCSS config by one of these means *and* also via "liferayTheme" -> "postcss", we throw an error.

Test plan:

- Confirm that old style of config still works by building liferay-theme-fjord with "liferayTheme" -> "postcss" -> `["autoprefixer"]`.
- Add a .postcssrc file and see this error:

    PostCSS must be configured in only one place but it was configured
    in both "liferayTheme" properties of the package.json and also in
    .postcssrc

- Remove that file and set a "postcss" config in the "package.json" instead and see this error:

    PostCSS must be configured in only one place but it was configured
    in both "liferayTheme" properties of the package.json and also in
    package.json "postcss"

- Remove the duplicate config from the "liferayTheme" config and see the build work.

I would have liked to add automated tests for this, but it is basically impractical to do anything above what we're already doing in the Jest test suite (ie. running the build and seeing the hook callbacks fired). So for now I am just going with manual QA.

See the individual commit messages in the PR for the details on the clean-up that I did along the way.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/126