### PR TITLE
feat: add ability to config PostCSS plug-ins (8.x) (#126) 

### DIFF
--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -12,7 +12,6 @@ const es = require('event-stream');
 const fs = require('fs-extra');
 const log = require('fancy-log');
 const path = require('path');
-const resolve = require('resolve');
 const tar = require('tar-fs');
 
 const lfrThemeConfig = require('./liferay_theme_config');
@@ -138,18 +137,12 @@ function isSassPartial(name) {
 function requireDependency(dependency, version) {
 	const depsPath = getDepsPath(pkg, dependency, version);
 
-	const dependencyPath = resolve.sync(dependency, {
-		basedir: depsPath,
-	});
+	const dependencyPath = require.resolve(dependency, {paths: [depsPath]});
 
 	return require(dependencyPath);
 }
 
-function resolveDependency(dependency, version, dirname) {
-	if (_.isUndefined(dirname)) {
-		dirname = true;
-	}
-
+function resolveDependency(dependency, version) {
 	const customPath = getCustomDependencyPath(dependency);
 
 	if (customPath) {
@@ -164,17 +157,7 @@ function resolveDependency(dependency, version, dirname) {
 
 	const depsPath = getDepsPath(pkg, dependency, version);
 
-	const dependencyPath = resolve.sync(dependency, {
-		basedir: depsPath,
-	});
-
-	let resolvedPath = require.resolve(dependencyPath);
-
-	if (dirname) {
-		resolvedPath = path.dirname(resolvedPath);
-	}
-
-	return resolvedPath;
+	return path.dirname(require.resolve(dependency, {paths: [depsPath]}));
 }
 
 module.exports = {

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -42,7 +42,6 @@
 		"package-json": "^5.0.0",
 		"plugin-error": "^1.0.1",
 		"portfinder": "^1.0.20",
-		"resolve": "^1.1.7",
 		"run-sequence": "^1.0.2",
 		"tar-fs": "^1.16.3",
 		"through2": "^2.0.0",

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -137,14 +137,7 @@ function getPostCSSOptions(config) {
 
 		postCSSOptions.enabled = true;
 
-		// We bundle autoprefixer automatically, so do not try to
-		// resolve it to the theme
 		postCSSOptions.plugins = config
-			.map(pluginName =>
-				pluginName === 'autoprefixer'
-					? pluginName
-					: themeUtil.resolveDependency(pluginName)
-			)
 			.map(pluginDependency => require(pluginDependency));
 	} else if (rc) {
 		postCSSOptions.enabled = true;

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const log = require('fancy-log');
@@ -88,15 +89,56 @@ function concatBourbonIncludePaths(includePaths) {
 	return includePaths.concat(createBourbonFile());
 }
 
+/**
+ * Returns the string `file` if a file with that name exists, and
+ * `false` otherwise.
+ *
+ * Example:
+ *
+ *     > exists('package.json')
+ *     'package.json'
+ */
+function exists(file) {
+	return fs.existsSync(file) && file;
+}
+
+/**
+ * Returns a string indicating which of the standard methods for
+ * configuring PostCSS applies to the current theme, if any. Otherwise,
+ * returns `false`.
+ */
+function getPostCSSRC() {
+	const themeConfig = lfrThemeConfig.getConfig(true);
+	return (
+		(themeConfig.hasOwnProperty('postcss') && 'package.json "postcss"') ||
+		exists('.postcssrc') ||
+		exists('.postcssrc.js') ||
+		exists('.postcssrc.json') ||
+		exists('.postcssrc.yml') ||
+		exists('postcss.config.js')
+	);
+}
+
 function getPostCSSOptions(config) {
 	const postCSSOptions = {
 		enabled: false,
 	};
 
-	// We bundle autoprefixer automatically, so do not try to resolve it to the theme
+	const rc = getPostCSSRC();
 
 	if (_.isArray(config) && config.length > 0) {
+		if (rc) {
+			throw new Error(
+				'PostCSS must be configured in only one place but it was ' +
+					'configured in both "liferayTheme" properties of the ' +
+					`package.json and also in ${rc}`
+			);
+		}
+
 		postCSSOptions.enabled = true;
+
+		// We bundle autoprefixer automatically, so do not try to
+		// resolve it to the theme
 		postCSSOptions.plugins = config
 			.map(pluginName =>
 				pluginName === 'autoprefixer'
@@ -104,6 +146,8 @@ function getPostCSSOptions(config) {
 					: themeUtil.resolveDependency(pluginName)
 			)
 			.map(pluginDependency => require(pluginDependency));
+	} else if (rc) {
+		postCSSOptions.enabled = true;
 	}
 
 	return postCSSOptions;

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -137,8 +137,9 @@ function getPostCSSOptions(config) {
 
 		postCSSOptions.enabled = true;
 
-		postCSSOptions.plugins = config
-			.map(pluginDependency => require(pluginDependency));
+		postCSSOptions.plugins = config.map(pluginDependency =>
+			require(pluginDependency)
+		);
 	} else if (rc) {
 		postCSSOptions.enabled = true;
 	}


### PR DESCRIPTION
This is the v8.x version of https://github.com/liferay/liferay-js-themes-toolkit/pull/289 — see that one for all the details, or read the individual commit messages.

I just cherry-picked the commits over: the one thing that was different is the `resolveDependency()` change, because the branches have diverged a bit on that one.