### PR TITLE
doc: remove Gulp entry from version table (v8.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,5 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 | Create themes for 7.1          | v8.x                     |
 | Upgrade a theme for 6.2 to 7.0 | v8.x                     |
 | Upgrade a theme for 7.0 to 7.1 | v8.x                     |
-| Run tasks using Gulp v3        | v8.x                     |
 | Create themes for 7.2          | v9.x                     |
 | Upgrade a theme for 7.1 to 7.2 | v9.x                     |


### PR DESCRIPTION
At the time I wrote the table, I thought we were going to use Gulp v3 in version 8 and Gulp v4 in version 9, but in the end we stayed with Gulp v3 in both, so we should remove it from the table to avoid confusion. (I already removed the reference to v4 in 9c66f058ffee7).