### PR TITLE
fix: failure to update after non-JS/CSS changes in watch mode (#291)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -276,23 +276,7 @@ module.exports = function(options) {
 	function getBuildTaskArray(resourceDir, defaultTaskArray) {
 		let taskArray = defaultTaskArray || [];
 
-		if (resourceDir === 'WEB-INF') {
-			taskArray = [
-				'build:clean',
-				'build:src',
-				'build:web-inf',
-				'deploy:folder',
-				'watch:reload',
-			];
-		} else if (resourceDir === 'templates') {
-			taskArray = [
-				'build:src',
-				'build:themelet-src',
-				'build:themelet-js-inject',
-				'deploy:folder',
-				'watch:reload',
-			];
-		} else if (resourceDir === 'css') {
+		if (resourceDir === 'css') {
 			taskArray = [
 				'build:clean',
 				'build:base',
@@ -309,7 +293,7 @@ module.exports = function(options) {
 		} else if (resourceDir === 'js') {
 			taskArray = ['build:src', 'watch:reload'];
 		} else {
-			taskArray = ['deploy:file'];
+			taskArray = ['deploy', 'watch:reload'];
 		}
 
 		return taskArray;


### PR DESCRIPTION
It seems that both "deploy:file" and "deploy:folder" are horribly broken, which means that on changing a template file nothing gets deployed.

If you look at the code, `fastDeploy()` looks for a non-existent "../../temp" folder relative to the theme files, so Gulp doesn't put anything there for the portal to pick up. I considered instead getting the "appServerPath" from the "liferay-theme.json" file, which does existing, and using its "temp" directory, but it is not clear what the internal structure of it should be, nor whether it will have the effect of reloading the module in the same way that the magical "deploy" folder does. In short, I think that this might have worked once upon a time in conjunction with the right Gogo Shell commands, but now our only choice is to do a slow-but-correct full deploy. "slow" is relative here, and may only be a few seconds in the typical case, and is certainly much better than "fast and broken".

Test plan: `gulp watch`, make a change to "src/templates/portal_normal.ptl", see rebuild and deploy occur, and see it reflected in tomcat log. Now make a change to "src/css/_custom.scss" and see it do a partial rebuild, and no output in tomcat log. In both cases, see the browser window reload automatically.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/291