### PR TITLE
feat: teach theme tasks to accept --sass-include-paths option (#305)

### DIFF
--- a/packages/liferay-theme-tasks/README.md
+++ b/packages/liferay-theme-tasks/README.md
@@ -201,7 +201,7 @@ Specifies a list of [PostCSS](https://postcss.org/) plugins to run on the compil
 
 type: `object`
 
-Whatever properties are set in sassOptions get passed to either [gulp-sass](https://www.npmjs.com/package/gulp-sass#options) or [gulp-ruby-sass](https://www.npmjs.com/package/gulp-ruby-sass#options) depending on what sass compiler is implemented.
+Whatever properties are set in sassOptions get passed to [gulp-sass](https://www.npmjs.com/package/gulp-sass#options).
 
 ## liferayTheme
 

--- a/packages/liferay-theme-tasks/lib/__tests__/options.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/options.test.js
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const argv = require('minimist')(process.argv.slice(2));
+const {getArgv} = require('../util');
 const path = require('path');
 
+const argv = getArgv();
 const initCwd = process.cwd();
 const baseThemePath = path.join(
 	__dirname,

--- a/packages/liferay-theme-tasks/lib/options.js
+++ b/packages/liferay-theme-tasks/lib/options.js
@@ -5,7 +5,7 @@
  */
 
 const _ = require('lodash');
-const minimist = require('minimist');
+const {getArgv} = require('./util');
 
 const lfrThemeConfig = require('./liferay_theme_config');
 
@@ -14,7 +14,7 @@ let options;
 function getOptions(config) {
 	if (!options || config) {
 		config = config || {};
-		config.argv = minimist(process.argv.slice(2));
+		config.argv = getArgv();
 		config.pathBuild = config.pathBuild || './build';
 		config.pathDist = config.pathDist || './dist';
 		config.pathSrc = config.pathSrc || './src';

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -5,7 +5,6 @@
  */
 
 const _ = require('lodash');
-const argv = require('minimist')(process.argv.slice(2));
 const exec = require('child_process').exec;
 const inquirer = require('inquirer');
 
@@ -14,8 +13,9 @@ const lfrThemeConfig = require('../liferay_theme_config');
 const NPMModulePrompt = require('./npm_module_prompt');
 const promptUtil = require('./prompt_util');
 const themeFinder = require('../theme_finder');
+const {getArgv} = require('../util');
 
-const moduleName = argv.name;
+const moduleName = getArgv().name;
 
 class ExtendPrompt {
 	constructor(...args) {

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -5,12 +5,12 @@
  */
 
 const _ = require('lodash');
-const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const childProcess = require('child_process');
 const es = require('event-stream');
 const fs = require('fs-extra');
 const log = require('fancy-log');
+const minimist = require('minimist');
 const path = require('path');
 const tar = require('tar-fs');
 
@@ -98,6 +98,10 @@ function dockerExec(containerName, command) {
 	);
 }
 
+function getArgv() {
+	return minimist(process.argv.slice(2));
+}
+
 function getLanguageProperties(pathBuild) {
 	const pathContent = path.join(pathBuild, 'WEB-INF/src/content');
 
@@ -143,6 +147,7 @@ function getCustomDependencyPath(dependency) {
 	let customPath;
 	const envVariable = CUSTOM_DEP_PATH_ENV_VARIABLE_MAP[dependency];
 	const flag = CUSTOM_DEP_PATH_FLAG_MAP[dependency];
+	const argv = getArgv();
 
 	if (flag && argv[flag]) {
 		customPath = argv[flag];
@@ -167,6 +172,7 @@ module.exports = {
 	DEPLOYMENT_STRATEGIES,
 	dockerCopy,
 	dockerExec,
+	getArgv,
 	getCustomDependencyPath,
 	getLanguageProperties,
 	isCssFile,

--- a/packages/liferay-theme-tasks/plugin/lib/options.js
+++ b/packages/liferay-theme-tasks/plugin/lib/options.js
@@ -7,11 +7,11 @@
 'use strict';
 
 var _ = require('lodash');
-var minimist = require('minimist');
 var path = require('path');
+var {getArgv} = require('../../lib/util');
 
 module.exports = function(options) {
-	var argv = minimist(process.argv.slice(2));
+	var argv = getArgv();
 
 	var CWD = process.cwd();
 

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -14,6 +14,8 @@ var os = require('os');
 var path = require('path');
 var sinon = require('sinon');
 
+var {getArgv} = require('../../lib/util');
+
 var gulp = new Gulp();
 
 chai.use(require('chai-fs'));
@@ -83,7 +85,7 @@ test('registerTasks should invoke extension functions', function(done) {
 
 	var extFunction = function(options) {
 		expect(options).toEqual({
-			argv: require('minimist')(process.argv.slice(2)),
+			argv: getArgv(),
 			distName: 'test-plugin-layouttpl',
 			extensions: [extFunction],
 			gulp,

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const colors = require('ansi-colors');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
@@ -150,6 +151,23 @@ function getSassIncludePaths() {
 
 	includePaths = concatBourbonIncludePaths(includePaths);
 	includePaths.push(path.dirname(require.resolve('compass-mixins')));
+
+	const argv = themeUtil.getArgv();
+	if (argv['sass-include-paths']) {
+		const customPaths = argv['sass-include-paths']
+			.split(',')
+			.map(item => path.resolve(item));
+		log(
+			'using custom SASS include paths:',
+			colors.magenta(customPaths.join(', '))
+		);
+		includePaths.push(...customPaths);
+	}
+
+	const themeNodeModules = path.resolve('node_modules');
+	if (fs.existsSync(themeNodeModules)) {
+		includePaths.push(themeNodeModules);
+	}
 
 	return includePaths;
 }


### PR DESCRIPTION
If supplied, this comma-separated list of include paths with be appended to the list of search paths provided to Sass. Relative paths are considered to be relative to the current working directory.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/305