### PR TITLE
fix: broken CSS and sign-in when using "watch" proxy (#309, #310)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -230,7 +230,7 @@ module.exports = function(options) {
 
 				const content = appendLivereloadTag
 					? body.toString() + livereloadTag
-					: body.toString();
+					: body;
 				res.end(content);
 			});
 		});


### PR DESCRIPTION
Our "watch" proxy was breaking the sign-in flow, CSS, and possibly other things that we don't know about yet because it was pre-pending the "livereload" script tag where it shouldn't go, instead at the end of the HTML response.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/309
Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/310