### PR TITLE
fix: broken CSS and sign-in when using "watch" proxy (8.x) (#309, #310)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -230,7 +230,7 @@ module.exports = function(options) {
 
 				const content = appendLivereloadTag
 					? body.toString() + livereloadTag
-					: body.toString();
+					: body;
 				res.end(content);
 			});
 		});


### PR DESCRIPTION
This is the v8 cherry-pick of the corresponding "master"/v9.x fix (#312).

I'll attach a screenshot showing me testing this with the 7.1 community binary.
