### PR TITLE
fix: make "watch" mode work with portal gzipped (#311)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -205,6 +205,12 @@ module.exports = function(options) {
 
 		const proxy = httpProxy.createServer();
 
+		proxy.on('proxyReq', function(proxyReq, _req, _res, _options) {
+			// Disable compression because it complicates the task of appending
+			// our livereload tag.
+			proxyReq.setHeader('Accept-Encoding', 'identity');
+		});
+
 		proxy.on('proxyRes', (proxyRes, req, res) => {
 			// Make sure that "web passes" (eg. header setting and such) still
 			// happen even though we are in "selfHandleResponse" mode.


### PR DESCRIPTION
Cherry-pick of v9 fix (#314) for v8.

Our watch mode was choking horribly trying to join a string onto gzipped content, causing the result page to be a garbled mess.

Test plan: Launch portal in production mode (ie. with GZipFilter turned on) and connect to proxy port (9080). See the request headers show: "Accept-Encoding: gzip", but server returns no "Content-Encoding: gzip"; now connect on non-proxy port (8080) and see "Content-Encoding: gzip". In both cases, page renders correctly.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/311