### PR TITLE
perf: avoid unnecessary buffering of responses in watch mode (#324)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -221,9 +221,8 @@ module.exports = function(options) {
 				}
 			}
 
-			let body = Buffer.from('');
 			proxyRes.on('data', data => {
-				body = Buffer.concat([body, data]);
+				res.write(data);
 			});
 
 			proxyRes.on('end', () => {
@@ -234,10 +233,11 @@ module.exports = function(options) {
 						'text/html'
 					) === 0;
 
-				const content = appendLivereloadTag
-					? body.toString() + livereloadTag
-					: body;
-				res.end(content);
+				if (appendLivereloadTag) {
+					res.end(livereloadTag);
+				} else {
+					res.end();
+				}
 			});
 		});
 


### PR DESCRIPTION
At the moment, we are [buffering the response](https://github.com/liferay/liferay-js-themes-toolkit/blob/8ed39dec06a0467b4/packages/liferay-theme-tasks/tasks/watch.js#L225-L227) that our proxy gets back from the upstream Liferay instance, because I copied [the example in the node-http-proxy docs](https://github.com/nodejitsu/node-http-proxy/#modify-response). 

In reality we don't need to buffer and can instead pass it directly on, which should make the watch mode more responsive.

Test plan: Create a new theme with `yo ./packages/generator-liferay-theme`, deploy and watch it by `cd`-ing into the generated theme and running `gulp watch`. Inspect network response and see live reload tag is appended at end, live reloading works when you edit an SCSS file, and all other resources continue to be correctly served. Sign in works.