### PR TITLE
perf: avoid unnecessary buffering of responses in watch mode (#324)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -221,9 +221,8 @@ module.exports = function(options) {
 				}
 			}
 
-			let body = Buffer.from('');
 			proxyRes.on('data', data => {
-				body = Buffer.concat([body, data]);
+				res.write(data);
 			});
 
 			proxyRes.on('end', () => {
@@ -234,10 +233,11 @@ module.exports = function(options) {
 						'text/html'
 					) === 0;
 
-				const content = appendLivereloadTag
-					? body.toString() + livereloadTag
-					: body;
-				res.end(content);
+				if (appendLivereloadTag) {
+					res.end(livereloadTag);
+				} else {
+					res.end();
+				}
 			});
 		});
 


### PR DESCRIPTION
This is the 8.x cherry-pick of #325.

At the moment, we are [buffering the response](https://github.com/liferay/liferay-js-themes-toolkit/blob/8ed39dec06a0467b4/packages/liferay-theme-tasks/tasks/watch.js#L225-L227) that our proxy gets back from the upstream Liferay instance, because I copied [the example in the node-http-proxy docs](https://github.com/nodejitsu/node-http-proxy/#modify-response). 

In reality we don't need to buffer and can instead pass it directly on, which should make the watch mode more responsive.

Test plan: #yolo (or rather, I'm confident that the testing done for the 9.x change shows that this clean cherry-pick will work as well).