### PR TITLE
feat: teach `gulp extend` to accept a package URL (9.x) (#266)

### DIFF
--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -23,19 +23,19 @@ const themeletDependencies = {
 	'themelet-1': {
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-1',
-		realPath: 'path/to/themelet-1',
+		__realPath__: 'path/to/themelet-1',
 		version: liferayVersion,
 	},
 	'themelet-2': {
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-2',
-		realPath: 'path/to/themelet-2',
+		__realPath__: 'path/to/themelet-2',
 		version: liferayVersion,
 	},
 	'themelet-3': {
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-3',
-		realPath: 'path/to/themelet-3',
+		__realPath__: 'path/to/themelet-3',
 		version: liferayVersion,
 	},
 };
@@ -476,7 +476,7 @@ it('_reducePkgData should reduce package data to specified set of properties', (
 	expect(pkgData).toEqual(originalData);
 
 	pkgData = prototype._reducePkgData({
-		realPath: '/some/path',
+		__realPath__: '/some/path',
 	});
 
 	expect(pkgData.path).toEqual('/some/path');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -286,7 +286,7 @@ it('_filterExtendType should set _extendType to input arg', () => {
 	expect(prototype._extendType).toBe('themelet');
 });
 
-it('_getDependencyInstallationArray should return absolute path if present or name of module', () => {
+it('_getDependencyInstallationArray should return paths, URLs or names', () => {
 	const dependencies = prototype._getDependencyInstallationArray({
 		'themelet-1': {
 			liferayTheme: {
@@ -316,12 +316,22 @@ it('_getDependencyInstallationArray should return absolute path if present or na
 			},
 			version: '1.0',
 		},
+		'themelet-4': {
+			liferayTheme: {
+				themelet: true,
+				version: '7.0',
+			},
+			name: 'themelet-4',
+			__packageURL__: 'https://registry.example.org/themelet-4-1.0.0.tgz',
+			version: '1.0',
+		},
 	});
 
 	expect(dependencies).toEqual([
 		'themelet-1@*',
 		'path/to/themelet-2',
 		'themelet-3@7_1_x',
+		'https://registry.example.org/themelet-4-1.0.0.tgz',
 	]);
 });
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -349,13 +349,13 @@ it('_getSelectedModules should pass', () => {
 it('_getThemeSourceChoices should return different choices based on _extendType property', () => {
 	let choices = prototype._getThemeSourceChoices();
 
-	expect(choices.length).toBe(2);
+	expect(choices.length).toBe(3);
 
 	prototype._extendType = 'theme';
 
 	choices = prototype._getThemeSourceChoices();
 
-	expect(choices).toHaveLength(5);
+	expect(choices).toHaveLength(6);
 });
 
 it('_getThemeSourceMessage should return appropriate message based on _extendType property', () => {

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -302,7 +302,7 @@ it('_getDependencyInstallationArray should return absolute path if present or na
 				version: '*',
 			},
 			name: 'themelet-2',
-			path: 'path/to/themelet-2',
+			__realPath__: 'path/to/themelet-2',
 			version: '1.0',
 		},
 		'themelet-3': {
@@ -393,7 +393,7 @@ it('_installDependencies should run child process that installs dependencies', d
 			if (err.cmd) {
 				expect(
 					err.cmd.indexOf(
-						'npm install themelet-1@* themelet-2@* themelet-3@*'
+						'npm install path/to/themelet-1 path/to/themelet-2 path/to/themelet-3'
 					) > -1
 				).toBe(true);
 			}

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -91,12 +91,12 @@ it('_afterPromptModule should pass answers to done prop or invoke _installTempMo
 	expect(prototype.done.getCall(1).calledWith(answers)).toBe(true);
 });
 
-it('_afterPromptModule should set modulePath property of answers object if realPath exists in pkg', () => {
+it('_afterPromptModule should set modulePath property of answers object if __realPath__ exists in pkg', () => {
 	const answers = {
 		module: 'some-theme',
 		modules: {
 			'some-theme': {
-				realPath: '/path/to/some-theme',
+				__realPath__: '/path/to/some-theme',
 			},
 		},
 	};

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -17,13 +17,13 @@ const themeletDependencies = {
 	'themelet-1': {
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-1',
-		realPath: 'path/to/themelet-1',
+		__realPath__: 'path/to/themelet-1',
 		version: liferayVersion,
 	},
 	'themelet-2': {
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-2',
-		realPath: 'path/to/themelet-2',
+		__realPath__: 'path/to/themelet-2',
 		version: liferayVersion,
 	},
 	'themelet-3': {

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -311,12 +311,12 @@ class ExtendPrompt {
 	}
 
 	_reducePkgData(pkg) {
-		const realPath = pkg.realPath;
+		const __realPath__ = pkg.__realPath__;
 
 		pkg = _.pick(pkg, ['liferayTheme', 'name', 'publishConfig', 'version']);
 
-		if (realPath) {
-			pkg.path = realPath;
+		if (__realPath__) {
+			pkg.path = __realPath__;
 		}
 
 		return pkg;

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -11,6 +11,7 @@ const inquirer = require('inquirer');
 const GlobalModulePrompt = require('./global_module_prompt');
 const lfrThemeConfig = require('../liferay_theme_config');
 const NPMModulePrompt = require('./npm_module_prompt');
+const URLPackagePrompt = require('./url_package_prompt');
 const promptUtil = require('./prompt_util');
 const themeFinder = require('../theme_finder');
 const {getArgv} = require('../util');
@@ -141,12 +142,17 @@ class ExtendPrompt {
 			if (themeSource === 'global') {
 				GlobalModulePrompt.prompt(
 					config,
-					_.bind(this._afterPromptModule, this)
+					this._afterPromptModule.bind(this)
 				);
 			} else if (themeSource === 'npm') {
 				NPMModulePrompt.prompt(
 					config,
-					_.bind(this._afterPromptModule, this)
+					this._afterPromptModule.bind(this)
+				);
+			} else if (themeSource === 'url') {
+				URLPackagePrompt.prompt(
+					config,
+					this._afterPromptModule.bind(this)
 				);
 			}
 		}
@@ -216,6 +222,10 @@ class ExtendPrompt {
 			{
 				name: 'Search npm registry (published modules)',
 				value: 'npm',
+			},
+			{
+				name: 'Specify a package URL',
+				value: 'url',
 			},
 		];
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -67,6 +67,7 @@ class ExtendPrompt {
 		const baseTheme = this.themeConfig.baseTheme;
 		const module = answers.module;
 		const modulePackages = answers.modules;
+		const pkg = modulePackages[module];
 
 		if (!module) {
 			this.done();
@@ -78,15 +79,15 @@ class ExtendPrompt {
 			lfrThemeConfig.removeDependencies([baseTheme.name]);
 		}
 
-		const reducedPkg = this._reducePkgData(modulePackages[module]);
+		const reducedPkg = this._reducePkgData(pkg);
 
 		lfrThemeConfig.setConfig({
 			baseTheme: reducedPkg,
 		});
 
-		this._saveDependencies([reducedPkg]);
+		this._saveDependencies([pkg]);
 
-		this._installDependencies([reducedPkg], () => this.done());
+		this._installDependencies([pkg], () => this.done());
 	}
 
 	_afterPromptThemelets(answers) {
@@ -168,11 +169,12 @@ class ExtendPrompt {
 		const themeVersion = this.themeConfig.version;
 
 		return _.map(dependencies, item => {
-			const path = item.path;
+			const pathOrURL = item.__realPath__ || item.__packageURL__;
 
-			return path
-				? path
-				: item.name + this._getDistTag(item, themeVersion, '@');
+			return (
+				pathOrURL ||
+				item.name + this._getDistTag(item, themeVersion, '@')
+			);
 		});
 	}
 
@@ -328,9 +330,10 @@ class ExtendPrompt {
 		const dependencies = _.reduce(
 			updatedData,
 			(result, item) => {
-				const moduleVersion = item.path
-					? item.path
-					: this._getDistTag(item, themeVersion);
+				const moduleVersion =
+					item.__realPath__ ||
+					item.__packageURL__ ||
+					this._getDistTag(item, themeVersion);
 
 				result[item.name] = moduleVersion;
 

--- a/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
@@ -32,8 +32,8 @@ class KickstartPrompt {
 
 		const pkg = answers.modules[module];
 
-		if (pkg && pkg.realPath) {
-			answers.modulePath = path.join(pkg.realPath, 'src');
+		if (pkg && pkg.__realPath__) {
+			answers.modulePath = path.join(pkg.__realPath__, 'src');
 
 			done(answers);
 		} else if (pkg) {

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -47,7 +47,7 @@ class URLPackagePrompt {
 		answers.module = config.name;
 		answers.modules = {
 			[config.name]: Object.assign({}, config, {
-				realPath: answers.packageURL,
+				__realPath__: answers.packageURL,
 			}),
 		};
 		this.done(answers);

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -47,7 +47,7 @@ class URLPackagePrompt {
 		answers.module = config.name;
 		answers.modules = {
 			[config.name]: Object.assign({}, config, {
-				__realPath__: answers.packageURL,
+				__packageURL__: answers.packageURL,
 			}),
 		};
 		this.done(answers);

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -1,0 +1,59 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const inquirer = require('inquirer');
+const {URL} = require('url');
+
+const themeFinder = require('../theme_finder');
+
+class URLPackagePrompt {
+	constructor(...args) {
+		this.init(...args);
+	}
+
+	init(config, cb) {
+		this.done = cb;
+
+		inquirer.prompt(
+			[
+				{
+					message: 'Enter the URL for the package:',
+					name: 'packageURL',
+					type: 'input',
+					validate: this._validatePackageURL,
+				},
+			],
+			this._afterPrompt.bind(this)
+		);
+	}
+
+	_validatePackageURL(packageURL, _answers) {
+		try {
+			new URL(packageURL);
+		} catch (err) {
+			return `"${packageURL}" is not a valid URL`;
+		}
+
+		return true;
+	}
+
+	_afterPrompt(answers) {
+		const config = themeFinder.getLiferayThemeModuleFromURL(
+			answers.packageURL
+		);
+		answers.module = config.name;
+		answers.modules = {
+			[config.name]: Object.assign({}, config, {
+				realPath: answers.packageURL,
+			}),
+		};
+		this.done(answers);
+	}
+}
+
+URLPackagePrompt.prompt = (config, cb) => new URLPackagePrompt(config, cb);
+
+module.exports = URLPackagePrompt;

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -43,44 +43,39 @@ function getLiferayThemeModule(name, cb) {
  * Given a package URL, attempts to download it, extract the package.json, and
  * validate it.
  */
-function getLiferayThemeModuleFromURL(url, cb) {
-	try {
-		// Throw if `url` is invalid.
-		new URL(url);
+function getLiferayThemeModuleFromURL(url) {
+	new URL(url);
 
-		let config;
+	let config;
 
-		// Install the package in a temporary directory in order to get
-		// the package.json.
-		withScratchDirectory(() => {
-			child_process.spawnSync('npm', ['init', '-y']);
+	// Install the package in a temporary directory in order to get
+	// the package.json.
+	withScratchDirectory(() => {
+		child_process.spawnSync('npm', ['init', '-y']);
 
-			// Ideally, we wouldn't install any dependencies at all, but this is
-			// the closest we can get (production only, skipping optional
-			// dependencies).
-			child_process.spawnSync('npm', [
-				'install',
-				'--ignore-scripts',
-				'--no-optional',
-				'--production',
-				url,
-			]);
+		// Ideally, we wouldn't install any dependencies at all, but this is
+		// the closest we can get (production only, skipping optional
+		// dependencies).
+		child_process.spawnSync('npm', [
+			'install',
+			'--ignore-scripts',
+			'--no-optional',
+			'--production',
+			url,
+		]);
 
-			// Just in case package name doesn't match URL basename, read it.
-			const {dependencies} = JSON.parse(fs.readFileSync('package.json'));
-			const themeName = Object.keys(dependencies)[0];
+		// Just in case package name doesn't match URL basename, read it.
+		const {dependencies} = JSON.parse(fs.readFileSync('package.json'));
+		const themeName = Object.keys(dependencies)[0];
 
-			const json = path.join('node_modules', themeName, 'package.json');
-			config = JSON.parse(fs.readFileSync(json));
-		});
+		const json = path.join('node_modules', themeName, 'package.json');
+		config = JSON.parse(fs.readFileSync(json));
+	});
 
-		if (!isLiferayTheme(config)) {
-			throw new Error(`URL ${url} is not a liferay-theme`);
-		} else {
-			return config;
-		}
-	} catch (err) {
-		cb(err);
+	if (!isLiferayTheme(config)) {
+		throw new Error(`URL ${url} is not a liferay-theme`);
+	} else {
+		return config;
 	}
 }
 

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -26,7 +26,7 @@ function getLiferayThemeModule(name, cb) {
 			name,
 		},
 		(err, pkg) => {
-			if (!isLiferayTheme(pkg)) {
+			if (pkg && !isLiferayTheme(pkg)) {
 				pkg = null;
 
 				err = new Error(

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -323,7 +323,7 @@ function searchGlobalModules(config, cb) {
 			try {
 				const json = require(path.join(item, 'package.json'));
 
-				json.realPath = item;
+				json.__realPath__ = item;
 
 				result.push(json);
 			} catch (err) {


### PR DESCRIPTION
This is the v9.x ("master" branch) version of #332.

It's basically a series of totally clean cherry-picks, except for the very last "test: provide a little extra test coverage" commit, for which I had to resolve a tiny conflict.

See the original pull for related discussion.