### PR TITLE
feat: handle lightweight tags in changelog script

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -119,7 +119,12 @@ async function getDate(commitish) {
 }
 
 async function getPreviousReleasedVersion(before) {
-	const describe = await git('describe', '--abbrev=0', `${before}~`);
+	const describe = await git(
+		'describe',
+		'--abbrev=0',
+		'--tags',
+		`${before}~`
+	);
 	return describe.trim();
 }
 


### PR DESCRIPTION
As noted in #334 we accidentally created a lightweight (ie. non-annotated) tag in the AlloyEditor project, which lead the changelog script to not "see" the previous release tag, seek to the one prior to that, and thus include some duplicate entries in the changelog.

We can avoid that by passing the `--tags` switch to `git describe`, but I'll also add a check in AlloyEditor to make sure we don't accidentally create non-annotated tags in the future.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/334