### PR TITLE
chore: Update theme dependencies for Liferay 7.2 release (#341)

### DIFF
--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -9,6 +9,6 @@ module.exports = {
 	'liferay-theme-tasks': '^9.1.2',
 	'compass-mixins': '0.12.10',
 	'liferay-frontend-common-css': '^1.0.4',
-	'liferay-frontend-theme-styled': '^4.0.0-alpha.1552930087997',
-	'liferay-frontend-theme-unstyled': '^4.0.0-alpha.1552930030671',
+	'liferay-frontend-theme-styled': '^4.0.7',
+	'liferay-frontend-theme-unstyled': '^4.0.4',
 };


### PR DESCRIPTION
Test plan: `yarn ci`; generate a theme with `yo ./packages/generator-liferay-theme`, inspect generated "package.json" and "node_modules" folder, see the requested versions have been included, `gulp deploy` the theme and see it work in running liferay-portal instance.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/341