### PR TITLE
feat: add a runtime NodeJS version check (#339)

### DIFF
--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+require('./lib/checkNodeVersion')();
+
 const _ = require('lodash');
 const globby = require('globby');
 const liferayPluginTasks = require('liferay-plugin-node-tasks');

--- a/packages/liferay-theme-tasks/lib/checkNodeVersion.js
+++ b/packages/liferay-theme-tasks/lib/checkNodeVersion.js
@@ -1,0 +1,27 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Rather than checking for a specific version of NodeJS, we check for features
+ * that we expect to be present.
+ */
+function checkNodeVersion() {
+	const REQUIREMENTS = [
+		// Added to NodeJS v7: https://nodejs.org/fa/blog/release/v7.0.0/
+		() => !!Object.values,
+	];
+
+	if (!REQUIREMENTS.every(Boolean)) {
+		// eslint-disable-next-line no-console
+		console.log(
+			'warning: liferay-theme-tasks requires a more recent version ' +
+				'of NodeJS - please consider upgrading: ' +
+				'https://nodejs.org/en/about/releases/'
+		);
+	}
+}
+
+module.exports = checkNodeVersion;


### PR DESCRIPTION
This is the 8.x cherry pick of the 9.x change (#343).

This should help people who run into issues like #339 where things aren't working due to an old NodeJS version. Now, we'll print a warning that they should upgrade, but we'll still try to run.

Test plan: In a generated theme with the gulpfile.js `require` pointing at my local "liferay-theme-tasks" repo, run `gulp --tasks` and see no warning. Then tweak the `REQUIREMENTS` to fail and run `gulp --tasks` again and see a warning.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/339