### PR TITLE
fix(tasks): non-CSS/JS file changes break CSS when using "watch" (#340)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -19,7 +19,6 @@ const themeUtil = require('../../lib/util');
 
 module.exports = function(options) {
 	const {gulp, pathBuild} = options;
-	const {storage} = gulp;
 
 	const handleScssError = err => {
 		if (options.watching) {
@@ -33,23 +32,9 @@ module.exports = function(options) {
 	const runSequence = require('run-sequence').use(gulp);
 
 	gulp.task('build:compile-css', function(cb) {
-		const changedFile = getSrcPathConfig(storage).changedFile;
-
-		// During watch task, exit task early if changed file is not css
-
-		if (
-			changedFile &&
-			changedFile.type === 'changed' &&
-			!themeUtil.isCssFile(changedFile.path)
-		) {
-			cb();
-
-			return;
-		}
-
-		const compileTask = 'build:compile-lib-sass';
-
-		runSequence(compileTask, cb);
+		// For backwards compatibility we keep this task around, but all it does
+		// is call through to the one that does the actual work:
+		runSequence('build:compile-lib-sass', cb);
 	});
 
 	gulp.task('build:compile-lib-sass', function(cb) {
@@ -180,14 +165,4 @@ function getSassOptions(sassOptions, defaults) {
 	}
 
 	return sassOptions;
-}
-
-function getSrcPathConfig(storage) {
-	const themeConfig = lfrThemeConfig.getConfig();
-
-	return {
-		changedFile: storage.get('changedFile'),
-		deployed: storage.get('deployed'),
-		version: themeConfig.version,
-	};
 }

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -28,7 +28,10 @@ const DEPLOYMENT_STRATEGIES = themeUtil.DEPLOYMENT_STRATEGIES;
 const EXPLODED_BUILD_DIR_NAME = '.web_bundle_build';
 const MIME_TYPES = {
 	'.css': 'text/css',
+	'.ico': 'image/x-icon',
 	'.js': 'text/javacript',
+	'.map': 'application/json',
+	'.svg': 'image/svg+xml',
 };
 
 /**


### PR DESCRIPTION
For non-CSS/JS changes, we call the "deploy" task, and the first thing that does is "build", and the first thing that does is "clean", which deletes the CSS.

We then had a short-circuit that skipped over compiling SCSS to CSS if the file that triggered the change wasn't a CSS file. Then when "watch:reload" reloads the window, we can't deliver the CSS (it was deleted and not rebuilt), so we send a 404 instead and everything is horribly broken.

The fix then is to remove the shortcircuit, because it is better to be a slower-but-working than faster-and-broken.

I kept the old task around even though it reduces to an empty layer of indirection, in the name of backwards compatibility.

Test plan: `gulp watch` in a theme and make edits to CSS and ".ftl" files.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/340