### PR TITLE
fix: Fix typo in JS MIME type (8.x) (#349)

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -29,7 +29,7 @@ const EXPLODED_BUILD_DIR_NAME = '.web_bundle_build';
 const MIME_TYPES = {
 	'.css': 'text/css',
 	'.ico': 'image/x-icon',
-	'.js': 'text/javacript',
+	'.js': 'text/javascript',
 	'.map': 'application/json',
 	'.svg': 'image/svg+xml',
 };


### PR DESCRIPTION
Fixes #349.

Test plan:
* Run `gulp watch`
* Run `curl -I http://localhost:9080/o/theme-name/js/main.js`
* See `Content-Type: text/javascript` in output