### PR TITLE
chore: strictly peg dependency versions (#352)

### DIFF
--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -4,11 +4,23 @@
  * SPDX-License-Identifier: MIT
  */
 
+/**
+ * Helper method that will complain noisily if we pass a non-strict version
+ * specifier (eg. "^1.0.0", "~1.0.0", ">1.0.0" etc).
+ */
+function strict(version) {
+	if (!version.match(/^\d/)) {
+		throw new Error(`Version ${version} is not strict`);
+	}
+
+	return version;
+}
+
 module.exports = {
 	gulp: '3.9.1',
 	'liferay-theme-tasks': '^9.1.3',
-	'compass-mixins': '0.12.10',
-	'liferay-frontend-common-css': '^1.0.4',
-	'liferay-frontend-theme-styled': '^4.0.7',
-	'liferay-frontend-theme-unstyled': '^4.0.4',
+	'compass-mixins': strict('0.12.10'),
+	'liferay-frontend-common-css': strict('1.0.4'),
+	'liferay-frontend-theme-styled': strict('4.0.7'),
+	'liferay-frontend-theme-unstyled': strict('4.0.4'),
 };


### PR DESCRIPTION
To guard against unintended breakages. And add a little wrapper that will blow up if we ever pass a non-strict dependency.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/352