### PR TITLE
docs: indicate the use of `--tag` when publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,11 +142,11 @@ We used to use Lerna to manage this repo, but as the number of packages has redu
 
 ```sh
 cd packages
-(cd liferay-theme-deps-7.0 && yarn publish)
-(cd liferay-theme-deps-7.1 && yarn publish)
-(cd liferay-theme-tasks && yarn publish)
-(cd generator-liferay-theme && yarn publish)
-(cd liferay-theme-mixins && yarn publish)
+(cd liferay-theme-deps-7.0 && yarn publish --tag 8.x)
+(cd liferay-theme-deps-7.1 && yarn publish --tag 8.x)
+(cd liferay-theme-tasks && yarn publish --tag 8.x)
+(cd generator-liferay-theme && yarn publish --tag 8.x)
+(cd liferay-theme-mixins && yarn publish --tag 8.x)
 ```
 
 We may partially automate this in the future, but don't actually anticipate much change on the 8.x branch moving forward, so it may not be worth it.


### PR DESCRIPTION
Because of the way NPM works, only one package will ever get the "latest" tag in the registry, which leads to all sorts of confusing behavior. `npm install` will grab the latest (most recently published), rather than the highest semver-satisfying version. So, if we publish 9.1.4, and then 8.0.11, `npm install` will grab the 8.x release.

So, to ensure that 9.x releases are always the "latest", we need to use tags for 8.x releases.