### PR TITLE
fix: prevent proxy errors from killing the watcher

### DIFF
--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -244,7 +244,7 @@ module.exports = function(options) {
 			});
 		});
 
-		proxy.on('error', (err) => {
+		proxy.on('error', err => {
 			// eslint-disable-next-line
 			console.error(err);
 		});

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -244,6 +244,11 @@ module.exports = function(options) {
 			});
 		});
 
+		proxy.on('error', (err) => {
+			// eslint-disable-next-line
+			console.error(err);
+		});
+
 		http.createServer((req, res) => {
 			const dispatchToProxy = () =>
 				proxy.web(req, res, {

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -201,7 +201,7 @@ module.exports = function(options) {
 		const livereloadTag = `<script src="http://localhost:${tinylrPort}/livereload.js"></script>`;
 		livereload = tinylr();
 		livereload.server.on('error', err => {
-			// eslint-disable-next-line
+			// eslint-disable-next-line no-console
 			console.error(err);
 		});
 		livereload.listen(tinylrPort);
@@ -245,7 +245,7 @@ module.exports = function(options) {
 		});
 
 		proxy.on('error', err => {
-			// eslint-disable-next-line
+			// eslint-disable-next-line no-console
 			console.error(err);
 		});
 
@@ -271,7 +271,7 @@ module.exports = function(options) {
 
 						fs.createReadStream(filepath)
 							.on('error', err => {
-								// eslint-disable-next-line
+								// eslint-disable-next-line no-console
 								console.error(err);
 							})
 							.pipe(res);


### PR DESCRIPTION
Like is being done with the livereload server, this will handle errors on the proxy server (e.g. socket hang up due to ECONNRESET) instead of allowing them to crash the watcher.