### PR TITLE
fix: Windows compatibility extending themes via URL (#365)

### DIFF
--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash');
 const async = require('async');
-const child_process = require('child_process');
 const fs = require('fs');
 const globby = require('globby');
 const npmKeyword = require('npm-keyword');
@@ -51,12 +50,12 @@ function getLiferayThemeModuleFromURL(url) {
 	// Install the package in a temporary directory in order to get
 	// the package.json.
 	withScratchDirectory(() => {
-		child_process.spawnSync('npm', ['init', '-y']);
+		spawn.sync('npm', ['init', '-y']);
 
 		// Ideally, we wouldn't install any dependencies at all, but this is
 		// the closest we can get (production only, skipping optional
 		// dependencies).
-		child_process.spawnSync('npm', [
+		spawn.sync('npm', [
 			'install',
 			'--ignore-scripts',
 			'--no-optional',

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -7,7 +7,7 @@
 const _ = require('lodash');
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
-const childProcess = require('child_process');
+const spawn = require('cross-spawn');
 const es = require('event-stream');
 const fs = require('fs-extra');
 const log = require('fancy-log');
@@ -67,7 +67,7 @@ function dockerCopy(containerName, sourceFolder, destFolder, sourceFiles, cb) {
 		es.wait(function(err, body) {
 			if (err) throw err;
 
-			const proc = childProcess.spawnSync(
+			const proc = spawn.sync(
 				'docker',
 				[
 					'exec',
@@ -94,7 +94,7 @@ function dockerCopy(containerName, sourceFolder, destFolder, sourceFiles, cb) {
 }
 
 function dockerExec(containerName, command) {
-	return childProcess.spawnSync(
+	return spawn.sync(
 		'docker',
 		['exec', containerName, 'sh', '-c', '"' + command + '"'],
 		{


### PR DESCRIPTION
Two parts to this fix:

- Use `spawn.sync` from the "cross-spawn" module, which fixes the failure to find the `npm` executable on Windows.
- Don't swallow errors when spawning.

I created https://github.com/liferay/liferay-js-themes-toolkit/issues/366 separately to track the task of adding a lint to stop us from using `child_process.spawnSync` in the future.

This is the 8.x version of the fix. I'll create a separate PR for the 9.x version.