### PR TITLE
fix: silent `npm install` failures on Windows in extend and kickstart

### DIFF
--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -398,24 +398,6 @@ it('_hasPublishTag should return true if publish tag exists', () => {
 	).toBeTruthy();
 });
 
-it('_installDependencies should run child process that installs dependencies', done => {
-	prototype._installDependencies(
-		themeletDependencies,
-		(err, _data) => {
-			if (err.cmd) {
-				expect(
-					err.cmd.indexOf(
-						'npm install path/to/themelet-1 path/to/themelet-2 path/to/themelet-3'
-					) > -1
-				).toBe(true);
-			}
-
-			done();
-		},
-		true
-	);
-});
-
 it('_isSupported should validate version', () => {
 	const version = '2.0';
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -141,28 +141,6 @@ it('_afterPromptThemeSource should invoke correct prompt based on themeSource an
 	GlobalModulePrompt.prototype.init = init;
 });
 
-it('_installTempModule should pass', done => {
-	const name = 'a-theme-name-that-should-never-exist';
-
-	prototype._installTempModule(
-		name,
-		function(err) {
-			const command =
-				'npm install --prefix ' +
-				path.join(process.cwd(), '.temp_node_modules') +
-				' ' +
-				name;
-
-			if (err.cmd) {
-				expect(err.cmd.indexOf(command) > -1).toBe(true);
-			}
-
-			done();
-		},
-		true
-	);
-});
-
 it('_promptThemeSource should pass', () => {
 	const prompt = inquirer.prompt;
 


### PR DESCRIPTION
Based on my experience in #367, I searched for other usages of `child_process` which might not work on Windows and found these two. I believe these two `npm install` were failing on Windows as a result.

Note that we have tests asserting that errors are emitted, but they were bad, so I removed them:

1. The tests shouldn't be actually running `npm install`; they should be using stubs.
2. However, in the implementation, errors are ignored. It seems pointless to verify that an error is emitted if you are going to ignore it anyway.

Also note the useless `hideOutput` flag that nobody is ever passing.

Test plan: run `gulp extend` in a generated theme.

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/365