### PR TITLE
fix: silent `npm install` failures on Windows in extend and kickstart

### DIFF
--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -396,24 +396,6 @@ it('_hasPublishTag should return true if publish tag exists', () => {
 	).toBeTruthy();
 });
 
-it('_installDependencies should run child process that installs dependencies', done => {
-	prototype._installDependencies(
-		themeletDependencies,
-		(err, _data) => {
-			if (err.cmd) {
-				expect(
-					err.cmd.indexOf(
-						'npm install path/to/themelet-1 path/to/themelet-2 path/to/themelet-3'
-					) > -1
-				).toBe(true);
-			}
-
-			done();
-		},
-		true
-	);
-});
-
 it('_isSupported should validate version', () => {
 	const version = '2.0';
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -139,28 +139,6 @@ it('_afterPromptThemeSource should invoke correct prompt based on themeSource an
 	GlobalModulePrompt.prototype.init = init;
 });
 
-it('_installTempModule should pass', done => {
-	const name = 'a-theme-name-that-should-never-exist';
-
-	prototype._installTempModule(
-		name,
-		function(err) {
-			const command =
-				'npm install --prefix ' +
-				path.join(process.cwd(), '.temp_node_modules') +
-				' ' +
-				name;
-
-			if (err.cmd) {
-				expect(err.cmd.indexOf(command) > -1).toBe(true);
-			}
-
-			done();
-		},
-		true
-	);
-});
-
 it('_promptThemeSource should pass', () => {
 	const prompt = inquirer.prompt;
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+const spawn = require('cross-spawn');
 const _ = require('lodash');
-const exec = require('child_process').exec;
 const inquirer = require('inquirer');
 
 const GlobalModulePrompt = require('./global_module_prompt');
@@ -260,15 +260,39 @@ class ExtendPrompt {
 		return config.publishConfig && config.publishConfig.tag;
 	}
 
-	_installDependencies(dependencies, cb, hideOutput) {
+	_installDependencies(dependencies, cb) {
 		const modules = this._getDependencyInstallationArray(dependencies);
 
-		const child = exec('npm install ' + modules.join(' '), cb);
+		const args = ['install', ...modules];
 
-		if (!hideOutput) {
-			child.stderr.pipe(process.stdout);
-			child.stdout.pipe(process.stdout);
-		}
+		const child = spawn('npm', args, {stdio: 'inherit'});
+
+		let done = false;
+
+		const finalize = () => {
+			if (!done) {
+				done = true;
+				cb();
+			}
+		};
+
+		child.on('error', error => {
+			// eslint-disable-next-line no-console
+			console.log.bind(error);
+
+			finalize();
+		});
+
+		child.on('exit', code => {
+			if (code) {
+				const command = `npm ${args.join(' ')}`;
+
+				// eslint-disable-next-line no-console
+				console.log(`Command: \`${command}\` exited with code ${code}`);
+			}
+
+			finalize();
+		});
 	}
 
 	_isSupported(supportedVersion, version) {

--- a/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {exec} = require('child_process');
+const spawn = require('cross-spawn');
 const inquirer = require('inquirer');
 const _ = require('lodash');
 const path = require('path');
@@ -61,21 +61,42 @@ class KickstartPrompt {
 		}
 	}
 
-	_installTempModule(moduleName, cb, hideOutput) {
+	_installTempModule(moduleName, cb) {
 		const tempNodeModulesPath = path.join(
 			process.cwd(),
 			'.temp_node_modules'
 		);
 
-		const child = exec(
-			'npm install --prefix ' + tempNodeModulesPath + ' ' + moduleName,
-			cb
-		);
+		const args = ['install', '--prefix', tempNodeModulesPath, moduleName];
 
-		if (!hideOutput) {
-			child.stdout.pipe(process.stdout);
-			child.stderr.pipe(process.stdout);
-		}
+		const child = spawn('npm', args, {stdio: 'inherit'});
+
+		let done = false;
+
+		const finalize = () => {
+			if (!done) {
+				done = true;
+				cb();
+			}
+		};
+
+		child.on('error', error => {
+			// eslint-disable-next-line no-console
+			console.log.bind(error);
+
+			finalize();
+		});
+
+		child.on('exit', code => {
+			if (code) {
+				const command = `npm ${args.join(' ')}`;
+
+				// eslint-disable-next-line no-console
+				console.log(`Command: \`${command}\` exited with code ${code}`);
+			}
+
+			finalize();
+		});
 	}
 
 	_promptThemeSource() {


### PR DESCRIPTION
Based on my experience in #367, I searched for other usages of `child_process` which might not work on Windows and found these two. I believe these two `npm install` were failing on Windows as a result.

Note that we have tests asserting that errors are emitted, but they were bad, so I removed them:

1. The tests shouldn't be actually running `npm install`; they should be using stubs.
2. However, in the implementation, errors are ignored. It seems pointless to verify that an error is emitted if you are going to ignore it anyway.

Also note the useless `hideOutput` flag that nobody is ever passing.

This is the 9.x port of the 8.x version of this fix (#368).

Related: https://github.com/liferay/liferay-js-themes-toolkit/issues/365