### PR TITLE
feat: make `yarn updatePackageVersions` change all usages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,6 @@ for PACKAGE in $(ls); do
 done
 
 cd ..
-# Edit the one place that needs changing manually:
-$EDITOR packages/liferay-theme-tasks/lib/lookup/dependencies.js
 
 # Update package inter-dependencies using yarn (updates yarn.lock):
 cd packages/generator-liferay-theme

--- a/update-package-versions-config.js
+++ b/update-package-versions-config.js
@@ -17,11 +17,15 @@ module.exports = {
 		/"liferay-theme-tasks": ".*"/g,
 		/'liferay-theme-deps-7.(\d)': '.*'/g,
 		/'liferay-theme-tasks': '.*'/g,
+		/dependencies\['liferay-theme-deps-7.0'\] = '.*';/,
+		/dependencies\['liferay-theme-deps-7.1'\] = '.*';/,
 	],
 	to: [
 		`"liferay-theme-deps-7.$1": "${version}"`,
 		`"liferay-theme-tasks": "${version}"`,
 		`'liferay-theme-deps-7.$1': '${version}'`,
 		`'liferay-theme-tasks': '${version}'`,
+		`dependencies['liferay-theme-deps-7.0'] = '${version}';`,
+		`dependencies['liferay-theme-deps-7.1'] = '${version}';`,
 	],
 };


### PR DESCRIPTION
Previously we still had to do a manual update. I can't remember why right now; maybe it was a misgiving about using a potentially brittle pattern -- in any case, the whole thing is brittle so we may as well go for it and fully automate it. If it breaks, it will break.