### PR TITLE
feat: configure Semantic Pull Requests bot (8.x)

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,7 @@
+---
+# Configuration for the Semantic Pull Request bot.
+# https://github.com/probot/semantic-pull-requests
+
+allowMergeCommits: true
+
+titleAndCommits: true


### PR DESCRIPTION
I believe that the bot has now been activated for this repo, so we can do exactly what we did in:

https://github.com/liferay/liferay-frontend-guidelines/pull/70

This is the 8.x version of:

https://github.com/liferay/liferay-js-themes-toolkit/pull/385

I don't know whether the bot will respect per-branch configuration, but I can see it at least ran on the similar PR I sent for the 1.x branch in the AlloyEditor repo:

https://github.com/liferay/alloy-editor/pull/1311