### PR TITLE
chore: update eslint, eslint-config-liferay, prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"devDependencies": {
-		"eslint": "^5.15.2",
-		"eslint-config-liferay": "^3.0.0",
+		"eslint": "^6.4.0",
+		"eslint-config-liferay": "^10.0.0",
 		"jest": "^24.1.0",
-		"prettier": "^1.16.4",
+		"prettier": "^1.18.2",
 		"sinon": "^4.4.6"
 	},
 	"private": true,

--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -11,15 +11,15 @@ const liferayThemeApp = require('../index');
 chai.use(require('chai-fs'));
 const chaiAssert = chai.assert;
 
-describe('liferay-theme:app unit tests', function() {
+describe('liferay-theme:app unit tests', () => {
 	var prototype;
 
-	beforeEach(function() {
+	beforeEach(() => {
 		prototype = Object.create(liferayThemeApp.prototype);
 	});
 
-	describe('_getArgs', function() {
-		it('creates new args object only once', function() {
+	describe('_getArgs', () => {
+		it('creates new args object only once', () => {
 			var args = prototype._getArgs();
 
 			chaiAssert.isObject(args);
@@ -34,8 +34,8 @@ describe('liferay-theme:app unit tests', function() {
 		});
 	});
 
-	describe('_getWhenFn', function() {
-		it('returns false when property has been set on argv and sets property on args object', function() {
+	describe('_getWhenFn', () => {
+		it('returns false when property has been set on argv and sets property on args object', () => {
 			prototype.args = {};
 			prototype.argv = {};
 
@@ -60,16 +60,16 @@ describe('liferay-theme:app unit tests', function() {
 			whenFn = prototype._getWhenFn(propertyName, flagName);
 		});
 
-		it('implements a validator fn', function() {
+		it('implements a validator fn', () => {
 			prototype.args = {};
 			prototype.argv = {};
 
 			const flagName = 'name';
 			const propertyName = 'themeName';
 
-			let whenFn = prototype._getWhenFn(propertyName, flagName, function(
+			let whenFn = prototype._getWhenFn(propertyName, flagName, (
 				_value
-			) {
+			) => {
 				chaiAssert.fail(
 					'Invoked validator with null value',
 					'Should have not invoked'
@@ -86,9 +86,9 @@ describe('liferay-theme:app unit tests', function() {
 
 			prototype.log = function() {};
 
-			whenFn = prototype._getWhenFn(propertyName, flagName, function(
+			whenFn = prototype._getWhenFn(propertyName, flagName, (
 				value
-			) {
+			) => {
 				chaiAssert(value);
 
 				return true;
@@ -100,9 +100,9 @@ describe('liferay-theme:app unit tests', function() {
 
 			prototype.args = {};
 
-			whenFn = prototype._getWhenFn(propertyName, flagName, function(
+			whenFn = prototype._getWhenFn(propertyName, flagName, (
 				_value
-			) {
+			) => {
 				return false;
 			});
 
@@ -112,8 +112,8 @@ describe('liferay-theme:app unit tests', function() {
 		});
 	});
 
-	describe('_isLiferayVersion', function() {
-		it('should check for valid Liferay versions', function() {
+	describe('_isLiferayVersion', () => {
+		it('should check for valid Liferay versions', () => {
 			chaiAssert.isTrue(
 				prototype._isLiferayVersion('7.2'),
 				0,
@@ -128,8 +128,8 @@ describe('liferay-theme:app unit tests', function() {
 		});
 	});
 
-	describe('_mixArgs', function() {
-		it('mixes props and args', function() {
+	describe('_mixArgs', () => {
+		it('mixes props and args', () => {
 			var props = prototype._mixArgs(
 				{
 					liferayVersion: '7.0',
@@ -149,8 +149,8 @@ describe('liferay-theme:app unit tests', function() {
 		});
 	});
 
-	describe('_setArgv', function() {
-		it('should set correct argv properties based on shorthand values', function() {
+	describe('_setArgv', () => {
+		it('should set correct argv properties based on shorthand values', () => {
 			var originalArgv = process.argv;
 
 			var mockArgv = [

--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -113,7 +113,7 @@ describe('liferay-theme:app unit tests', () => {
 	});
 
 	describe('_isLiferayVersion', () => {
-		it('should check for valid Liferay versions', () => {
+		it('checks for valid Liferay versions', () => {
 			chaiAssert.isTrue(
 				prototype._isLiferayVersion('7.2'),
 				0,
@@ -150,7 +150,7 @@ describe('liferay-theme:app unit tests', () => {
 	});
 
 	describe('_setArgv', () => {
-		it('should set correct argv properties based on shorthand values', () => {
+		it('sets correct argv properties based on shorthand values', () => {
 			var originalArgv = process.argv;
 
 			var mockArgv = [

--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -67,14 +67,16 @@ describe('liferay-theme:app unit tests', () => {
 			const flagName = 'name';
 			const propertyName = 'themeName';
 
-			let whenFn = prototype._getWhenFn(propertyName, flagName, (
-				_value
-			) => {
-				chaiAssert.fail(
-					'Invoked validator with null value',
-					'Should have not invoked'
-				);
-			});
+			let whenFn = prototype._getWhenFn(
+				propertyName,
+				flagName,
+				_value => {
+					chaiAssert.fail(
+						'Invoked validator with null value',
+						'Should have not invoked'
+					);
+				}
+			);
 
 			chaiAssert.isFunction(whenFn);
 			chaiAssert(whenFn({}));
@@ -86,9 +88,7 @@ describe('liferay-theme:app unit tests', () => {
 
 			prototype.log = function() {};
 
-			whenFn = prototype._getWhenFn(propertyName, flagName, (
-				value
-			) => {
+			whenFn = prototype._getWhenFn(propertyName, flagName, value => {
 				chaiAssert(value);
 
 				return true;
@@ -100,9 +100,7 @@ describe('liferay-theme:app unit tests', () => {
 
 			prototype.args = {};
 
-			whenFn = prototype._getWhenFn(propertyName, flagName, (
-				_value
-			) => {
+			whenFn = prototype._getWhenFn(propertyName, flagName, _value => {
 				return false;
 			});
 

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -25,8 +25,8 @@ module.exports = class extends Generator {
 		this.pkg = pkg;
 
 		this._insight = new Insight({
-			trackingCode: 'UA-69122110-1',
 			pkg,
+			trackingCode: 'UA-69122110-1',
 		});
 	}
 
@@ -187,9 +187,9 @@ module.exports = class extends Generator {
 				when: instance._getWhenFn('themeId', 'id', isString),
 			},
 			{
+				choices: ['7.2'],
 				message: 'Which version of Liferay is this theme for?',
 				name: 'liferayVersion',
-				choices: ['7.2'],
 				type: 'list',
 				when: instance._getWhenFn(
 					'liferayVersion',

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -14,8 +14,8 @@ const path = require('path');
 const Generator = require('yeoman-generator');
 const yosay = require('yosay');
 
-const {getVersionSupportMessage} = require('../common/messages');
 const isString = require('../common/isString');
+const {getVersionSupportMessage} = require('../common/messages');
 const normalizeName = require('../common/normalizeName');
 
 module.exports = class extends Generator {

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -207,10 +207,10 @@ module.exports = class extends Base {
 				when: instance._getWhenFn('layoutId', 'id', isString),
 			},
 			{
+				choices: ['7.2'],
 				message:
 					'Which version of Liferay is this layout template for?',
 				name: 'liferayVersion',
-				choices: ['7.2'],
 				type: 'list',
 				when: instance._getWhenFn(
 					'liferayVersion',

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -60,7 +60,9 @@ module.exports = class extends Base {
 
 			fs.stat(themePackagePath, (err, stat) => {
 				if (!err && stat.isFile()) {
-					const themePackage = require(themePackagePath);
+					const themePackage = JSON.parse(
+						fs.readfileSync(themePackagePath, 'utf8')
+					);
 
 					if (themePackage.liferayTheme) {
 						layoutDirName = path.join(

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -7,11 +7,11 @@
 'use strict';
 
 const fs = require('fs');
-const LayoutCreator = require('../../lib/layout_creator');
-const minimist = require('minimist');
 const devDependencies = require('liferay-theme-tasks/lib/devDependencies');
+const minimist = require('minimist');
 const path = require('path');
 
+const LayoutCreator = require('../../lib/layout_creator');
 const Base = require('../app');
 const isString = require('../common/isString');
 const normalizeName = require('../common/normalizeName');
@@ -58,7 +58,7 @@ module.exports = class extends Base {
 
 			const themePackagePath = path.join(process.cwd(), 'package.json');
 
-			fs.stat(themePackagePath, function(err, stat) {
+			fs.stat(themePackagePath, (err, stat) => {
 				if (!err && stat.isFile()) {
 					const themePackage = require(themePackagePath);
 

--- a/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
@@ -15,7 +15,7 @@ const assert = chai.assert;
 describe('liferay-theme:themelet unit tests', () => {
 	describe('_isLiferayVersion', () => {
 		it('checks for valid Liferay versions', () => {
-			_.forEach(['Any', '7.2'], (version) => {
+			_.forEach(['Any', '7.2'], version => {
 				assert.isTrue(
 					liferayThemeThemelet.prototype._isLiferayVersion(version),
 					0,

--- a/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
@@ -12,10 +12,10 @@ const liferayThemeThemelet = require('../index');
 chai.use(require('chai-fs'));
 const assert = chai.assert;
 
-describe('liferay-theme:themelet unit tests', function() {
-	describe('_isLiferayVersion', function() {
-		it('checks for valid Liferay versions', function() {
-			_.forEach(['Any', '7.2'], function(version) {
+describe('liferay-theme:themelet unit tests', () => {
+	describe('_isLiferayVersion', () => {
+		it('checks for valid Liferay versions', () => {
+			_.forEach(['Any', '7.2'], (version) => {
 				assert.isTrue(
 					liferayThemeThemelet.prototype._isLiferayVersion(version),
 					0,

--- a/packages/generator-liferay-theme/generators/themelet/index.js
+++ b/packages/generator-liferay-theme/generators/themelet/index.js
@@ -74,7 +74,7 @@ module.exports = class extends Base {
 
 		const prompts = super._getPrompts.call(instance);
 
-		return prompts.reduce(function(result, item) {
+		return prompts.reduce((result, item) => {
 			const name = item.name;
 
 			if (name == 'themeName') {

--- a/packages/generator-liferay-theme/gulpfile.js
+++ b/packages/generator-liferay-theme/gulpfile.js
@@ -9,6 +9,6 @@
 var coveralls = require('gulp-coveralls');
 var gulp = require('gulp');
 
-gulp.task('coveralls', function() {
+gulp.task('coveralls', () => {
 	gulp.src('coverage/**/lcov.info').pipe(coveralls());
 });

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -25,7 +25,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('constructor', () => {
-		it('should set options as instance properties and throw error if after function is not set', () => {
+		it('sets options as instance properties and throw error if after function is not set', () => {
 			var init = LayoutCreator.prototype.init;
 
 			LayoutCreator.prototype.init = sinon.spy();
@@ -50,7 +50,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('init', () => {
-		it('should set rows to empty array and init prompting if rowData is undefined', () => {
+		it('sets rows to empty array and init prompting if rowData is undefined', () => {
 			prototype.after = sinon.spy();
 			prototype._promptRow = sinon.spy();
 
@@ -63,7 +63,7 @@ describe('LayoutCreator', () => {
 			sinonAssert.notCalled(prototype.after);
 		});
 
-		it('should use rowData if defined and skip prompting', () => {
+		it('uses rowData if defined and skip prompting', () => {
 			prototype._promptRow = sinon.spy();
 			prototype._renderLayoutTemplate = sinon.stub().returns('template');
 			prototype.after = sinon.spy();
@@ -85,7 +85,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('prompt', () => {
-		it('should pass arguments to inquirer.prompt', () => {
+		it('passes arguments to inquirer.prompt', () => {
 			var prompt = inquirer.prompt;
 
 			inquirer.prompt = sinon.spy();
@@ -105,7 +105,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_addRow', () => {
-		it('should add new row and print layout', () => {
+		it('adds new row and print layout', () => {
 			prototype._printLayoutPreview = sinon.spy();
 			prototype.rows = [];
 
@@ -130,7 +130,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_addWhiteSpace', () => {
-		it('should add whitespace', () => {
+		it('adds whitespace', () => {
 			var choices = [];
 
 			prototype._addWhiteSpace(choices);
@@ -144,7 +144,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPrompt', () => {
-		it('should process data returned from prompts and render template passing content to after property', () => {
+		it('processes data returned from prompts and render template passing content to after property', () => {
 			prototype.after = sinon.spy();
 			prototype.className = 'class-name';
 			prototype.rows = [
@@ -167,7 +167,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPromptColumnCount', () => {
-		it('should should pass columnCount to cb function', () => {
+		it('passes columnCount to cb function', () => {
 			var answers = {
 				columnCount: 3,
 			};
@@ -182,7 +182,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPromptColumnWidths', () => {
-		it('should should pass columnCount to cb function', () => {
+		it('pass columnCount to cb function', () => {
 			prototype._addRow = sinon.spy();
 			prototype.rows = [1];
 
@@ -201,7 +201,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPromptFinishRow', () => {
-		it('should follow correct workflow based on selection', () => {
+		it('follows correct workflow based on selection', () => {
 			var cbSpy = sinon.spy();
 			prototype.rows = [1];
 
@@ -253,7 +253,7 @@ describe('LayoutCreator', () => {
 			sinonAssert.calledOnce(prototype._promptRow);
 		});
 
-		it('should not call anything if invalid value', () => {
+		it('does not call anything if invalid value', () => {
 			var cbSpy = sinon.spy();
 			prototype.rows = [1];
 
@@ -276,7 +276,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPromptInsertRow', () => {
-		it('should set rowInserIndex based on answers and pass cb to _promptRow', () => {
+		it('sets rowInserIndex based on answers and pass cb to _promptRow', () => {
 			var cb = _.noop;
 
 			prototype._promptRow = sinon.spy();
@@ -294,7 +294,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_afterPromptRemoveRow', () => {
-		it('should pass rowIndex answer to _removeRow and re-prompt finish row', () => {
+		it('passes rowIndex answer to _removeRow and re-prompt finish row', () => {
 			prototype._promptFinishRow = sinon.spy();
 			prototype._removeRow = sinon.spy();
 			prototype.rows = [2];
@@ -314,7 +314,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_formatInlineChoicePreview', () => {
-		it('should return formatted preview', () => {
+		it('returns formatted preview', () => {
 			var preview = prototype._formatInlineChoicePreview(2, 2);
 
 			assert.match(preview, /\S+\s{2}\S+\s{2}\S+\s{8}/);
@@ -330,7 +330,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_formatPercentageValue', () => {
-		it('should return formatted label with column width percentage', () => {
+		it('returns formatted label with column width percentage', () => {
 			prototype._formatInlineChoicePreview = sinon
 				.stub()
 				.returns('preview');
@@ -383,7 +383,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getColumnClassNames', () => {
-		it('should return appropriate column classes', () => {
+		it('returns appropriate column classes', () => {
 			var classNames = prototype._getColumnClassNames(1, 1);
 
 			assert.equal(classNames[0], 'portlet-column-only');
@@ -406,7 +406,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getColumnWidthChoices', () => {
-		it('should return limited width choices based on columnIndex, columnCount, and available row width', () => {
+		it('returns limited width choices based on columnIndex, columnCount, and available row width', () => {
 			var choices = prototype._getColumnWidthChoices(0, 1, {});
 
 			assert.equal(choices.length, 1);
@@ -434,7 +434,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getFinishRowChoices', () => {
-		it('should only return add option if rows property is empty', () => {
+		it('only returns add option if rows property is empty', () => {
 			var rows = [];
 
 			var choices = prototype._getFinishRowChoices(rows);
@@ -454,7 +454,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getInsertRowChoices', () => {
-		it('should return compact layout preview where row borders are choices', () => {
+		it('returns compact layout preview where row borders are choices', () => {
 			prototype.rows = [
 				{
 					0: 3,
@@ -513,7 +513,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getRemoveRowChoices', () => {
-		it('should return compact layout preview where row bodies are choices', () => {
+		it('returns compact layout preview where row bodies are choices', () => {
 			prototype.rows = [
 				{
 					0: 3,
@@ -568,7 +568,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_getRowNumber', () => {
-		it('should return next row number for labels and messages', () => {
+		it('returns next row number for labels and messages', () => {
 			prototype.rows = [1, 2];
 
 			var rowNumber = prototype._getRowNumber();
@@ -584,7 +584,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_preprocessLayoutTemplateData', () => {
-		it('should convert prompt data to data that template can easily process', () => {
+		it('converts prompt data to data that template can easily process', () => {
 			var rows = [
 				{
 					0: 2,
@@ -649,7 +649,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_printLayoutPreview', () => {
-		it('should print layout preview', () => {
+		it('prints layout preview', () => {
 			prototype.rows = [[6, 6], [3, 3, 6]];
 
 			prototype._stdoutWrite = sinon.spy();
@@ -675,7 +675,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptColumnCount', () => {
-		it('should prompt user for column count using correct row number in prompt message', () => {
+		it('prompts user for column count using correct row number in prompt message', () => {
 			prototype.prompt = sinon.spy();
 
 			prototype.rows = [];
@@ -711,7 +711,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptColumnWidths', () => {
-		it('should prompt user for column widths', () => {
+		it('prompts user for column widths', () => {
 			prototype.prompt = sinon.spy();
 			prototype.rows = [];
 
@@ -746,7 +746,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptFinishRow', () => {
-		it('should prompt user for next action (add, insert, remove, finish)', () => {
+		it('prompts user for next action (add, insert, remove, finish)', () => {
 			assertPromptFn(prototype, '_promptFinishRow', [[], _.noop], {
 				message: 'What now?',
 				name: 'finish',
@@ -755,7 +755,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptInsertRow', () => {
-		it('should prompt user for where they want to insert row', () => {
+		it('prompts user for where they want to insert row', () => {
 			assertPromptFn(prototype, '_promptInsertRow', [_.noop], {
 				message: 'Where would you like to insert a new row?',
 				name: 'rowIndex',
@@ -764,7 +764,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptRemoveRow', () => {
-		it('should prompt user for what row they want to remove', () => {
+		it('prompts user for what row they want to remove', () => {
 			assertPromptFn(prototype, '_promptRemoveRow', [_.noop], {
 				message: 'What row would you like to remove?',
 				name: 'rowIndex',
@@ -773,7 +773,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptRow', () => {
-		it('should remove last row and print layout', (done) => {
+		it('removes last row and print layout', (done) => {
 			var waterfallSpy = sinon.spy();
 
 			var getWaterfallFunction = function(name) {
@@ -820,7 +820,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_removeRow', () => {
-		it('should remove row by index and print layout', () => {
+		it('removes row by index and print layout', () => {
 			prototype._printLayoutPreview = sinon.spy();
 			prototype.rows = [1, 2, 3];
 
@@ -837,7 +837,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_renderPreviewLine', () => {
-		it('should render preview line', () => {
+		it('renders preview line', () => {
 			var line = prototype._renderPreviewLine({
 				0: 4,
 				1: 8,
@@ -866,7 +866,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_renderLayoutTemplate', () => {
-		it('should compile data into valid template', () => {
+		it('compiles data into valid template', () => {
 			var fileOptions = {
 				encoding: 'utf8',
 			};
@@ -902,7 +902,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_replaceAt', () => {
-		it('should replace string character at index', () => {
+		it('replaces string character at index', () => {
 			assert.equal(prototype._replaceAt('string', 0, 'x'), 'xtring');
 			assert.equal(prototype._replaceAt('string', 2, 'x'), 'stxing');
 			assert.equal(prototype._replaceAt('string', 6, 'x'), 'stringx');
@@ -916,7 +916,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_validateColumnCount', () => {
-		it('should validate column count', () => {
+		it('validates column count', () => {
 			var errMessage = 'Please enter a number between 1 and 12!';
 
 			var retVal = prototype._validateColumnCount(1);

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -619,10 +619,10 @@ describe('LayoutCreator', () => {
 
 			var number = 0;
 
-			_.forEach(rowDataFromObjects, (row) => {
+			_.forEach(rowDataFromObjects, row => {
 				assert(_.isArray(row), 'each row is an array');
 
-				_.forEach(row, (column) => {
+				_.forEach(row, column => {
 					assert(_.isObject(column), 'each row is an array');
 
 					number++;
@@ -773,7 +773,7 @@ describe('LayoutCreator', () => {
 	});
 
 	describe('_promptRow', () => {
-		it('removes last row and print layout', (done) => {
+		it('removes last row and print layout', done => {
 			var waterfallSpy = sinon.spy();
 
 			var getWaterfallFunction = function(name) {

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const chai = require('chai');
 const fs = require('fs');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 const path = require('path');
 const sinon = require('sinon');
 const stripAnsi = require('strip-ansi');
@@ -17,15 +17,15 @@ const sinonAssert = sinon.assert;
 
 const LayoutCreator = require('../../lib/layout_creator');
 
-describe('LayoutCreator', function() {
+describe('LayoutCreator', () => {
 	var prototype;
 
-	beforeEach(function() {
+	beforeEach(() => {
 		prototype = _.create(LayoutCreator.prototype);
 	});
 
-	describe('constructor', function() {
-		it('should set options as instance properties and throw error if after function is not set', function() {
+	describe('constructor', () => {
+		it('should set options as instance properties and throw error if after function is not set', () => {
 			var init = LayoutCreator.prototype.init;
 
 			LayoutCreator.prototype.init = sinon.spy();
@@ -39,7 +39,7 @@ describe('LayoutCreator', function() {
 			assert.equal(layoutCreator.className, 'class-name');
 			sinonAssert.calledOnce(LayoutCreator.prototype.init);
 
-			assert.throws(function() {
+			assert.throws(() => {
 				new LayoutCreator({
 					className: 'class-name',
 				});
@@ -49,8 +49,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('init', function() {
-		it('should set rows to empty array and init prompting if rowData is undefined', function() {
+	describe('init', () => {
+		it('should set rows to empty array and init prompting if rowData is undefined', () => {
 			prototype.after = sinon.spy();
 			prototype._promptRow = sinon.spy();
 
@@ -63,7 +63,7 @@ describe('LayoutCreator', function() {
 			sinonAssert.notCalled(prototype.after);
 		});
 
-		it('should use rowData if defined and skip prompting', function() {
+		it('should use rowData if defined and skip prompting', () => {
 			prototype._promptRow = sinon.spy();
 			prototype._renderLayoutTemplate = sinon.stub().returns('template');
 			prototype.after = sinon.spy();
@@ -84,8 +84,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('prompt', function() {
-		it('should pass arguments to inquirer.prompt', function() {
+	describe('prompt', () => {
+		it('should pass arguments to inquirer.prompt', () => {
 			var prompt = inquirer.prompt;
 
 			inquirer.prompt = sinon.spy();
@@ -104,8 +104,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_addRow', function() {
-		it('should add new row and print layout', function() {
+	describe('_addRow', () => {
+		it('should add new row and print layout', () => {
 			prototype._printLayoutPreview = sinon.spy();
 			prototype.rows = [];
 
@@ -129,8 +129,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_addWhiteSpace', function() {
-		it('should add whitespace', function() {
+	describe('_addWhiteSpace', () => {
+		it('should add whitespace', () => {
 			var choices = [];
 
 			prototype._addWhiteSpace(choices);
@@ -143,8 +143,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPrompt', function() {
-		it('should process data returned from prompts and render template passing content to after property', function() {
+	describe('_afterPrompt', () => {
+		it('should process data returned from prompts and render template passing content to after property', () => {
 			prototype.after = sinon.spy();
 			prototype.className = 'class-name';
 			prototype.rows = [
@@ -166,8 +166,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPromptColumnCount', function() {
-		it('should should pass columnCount to cb function', function() {
+	describe('_afterPromptColumnCount', () => {
+		it('should should pass columnCount to cb function', () => {
 			var answers = {
 				columnCount: 3,
 			};
@@ -181,8 +181,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPromptColumnWidths', function() {
-		it('should should pass columnCount to cb function', function() {
+	describe('_afterPromptColumnWidths', () => {
+		it('should should pass columnCount to cb function', () => {
 			prototype._addRow = sinon.spy();
 			prototype.rows = [1];
 
@@ -200,8 +200,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPromptFinishRow', function() {
-		it('should follow correct workflow based on selection', function() {
+	describe('_afterPromptFinishRow', () => {
+		it('should follow correct workflow based on selection', () => {
 			var cbSpy = sinon.spy();
 			prototype.rows = [1];
 
@@ -253,7 +253,7 @@ describe('LayoutCreator', function() {
 			sinonAssert.calledOnce(prototype._promptRow);
 		});
 
-		it('should not call anything if invalid value', function() {
+		it('should not call anything if invalid value', () => {
 			var cbSpy = sinon.spy();
 			prototype.rows = [1];
 
@@ -275,8 +275,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPromptInsertRow', function() {
-		it('should set rowInserIndex based on answers and pass cb to _promptRow', function() {
+	describe('_afterPromptInsertRow', () => {
+		it('should set rowInserIndex based on answers and pass cb to _promptRow', () => {
 			var cb = _.noop;
 
 			prototype._promptRow = sinon.spy();
@@ -293,8 +293,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_afterPromptRemoveRow', function() {
-		it('should pass rowIndex answer to _removeRow and re-prompt finish row', function() {
+	describe('_afterPromptRemoveRow', () => {
+		it('should pass rowIndex answer to _removeRow and re-prompt finish row', () => {
 			prototype._promptFinishRow = sinon.spy();
 			prototype._removeRow = sinon.spy();
 			prototype.rows = [2];
@@ -313,8 +313,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_formatInlineChoicePreview', function() {
-		it('should return formatted preview', function() {
+	describe('_formatInlineChoicePreview', () => {
+		it('should return formatted preview', () => {
 			var preview = prototype._formatInlineChoicePreview(2, 2);
 
 			assert.match(preview, /\S+\s{2}\S+\s{2}\S+\s{8}/);
@@ -329,8 +329,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_formatPercentageValue', function() {
-		it('should return formatted label with column width percentage', function() {
+	describe('_formatPercentageValue', () => {
+		it('should return formatted label with column width percentage', () => {
 			prototype._formatInlineChoicePreview = sinon
 				.stub()
 				.returns('preview');
@@ -350,7 +350,7 @@ describe('LayoutCreator', function() {
 				'12/12 - 100%',
 			];
 
-			_.forEach(labels, function(label, index) {
+			_.forEach(labels, (label, index) => {
 				assert(
 					_.startsWith(
 						prototype._formatPercentageValue(index + 1),
@@ -361,7 +361,7 @@ describe('LayoutCreator', function() {
 
 			sinonAssert.notCalled(prototype._formatInlineChoicePreview);
 
-			_.forEach(labels, function(label, index) {
+			_.forEach(labels, (label, index) => {
 				var formattedLabel = prototype._formatPercentageValue(
 					index + 1,
 					0,
@@ -382,8 +382,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getColumnClassNames', function() {
-		it('should return appropriate column classes', function() {
+	describe('_getColumnClassNames', () => {
+		it('should return appropriate column classes', () => {
 			var classNames = prototype._getColumnClassNames(1, 1);
 
 			assert.equal(classNames[0], 'portlet-column-only');
@@ -405,8 +405,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getColumnWidthChoices', function() {
-		it('should return limited width choices based on columnIndex, columnCount, and available row width', function() {
+	describe('_getColumnWidthChoices', () => {
+		it('should return limited width choices based on columnIndex, columnCount, and available row width', () => {
 			var choices = prototype._getColumnWidthChoices(0, 1, {});
 
 			assert.equal(choices.length, 1);
@@ -433,8 +433,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getFinishRowChoices', function() {
-		it('should only return add option if rows property is empty', function() {
+	describe('_getFinishRowChoices', () => {
+		it('should only return add option if rows property is empty', () => {
 			var rows = [];
 
 			var choices = prototype._getFinishRowChoices(rows);
@@ -453,8 +453,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getInsertRowChoices', function() {
-		it('should return compact layout preview where row borders are choices', function() {
+	describe('_getInsertRowChoices', () => {
+		it('should return compact layout preview where row borders are choices', () => {
 			prototype.rows = [
 				{
 					0: 3,
@@ -470,7 +470,7 @@ describe('LayoutCreator', function() {
 
 			let choiceValue = 0;
 
-			_.forEach(choices, function(choice, index) {
+			_.forEach(choices, (choice, index) => {
 				index = index + 1;
 
 				if (index % 2 == 0) {
@@ -512,8 +512,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getRemoveRowChoices', function() {
-		it('should return compact layout preview where row bodies are choices', function() {
+	describe('_getRemoveRowChoices', () => {
+		it('should return compact layout preview where row bodies are choices', () => {
 			prototype.rows = [
 				{
 					0: 3,
@@ -529,7 +529,7 @@ describe('LayoutCreator', function() {
 
 			let choiceValue = 0;
 
-			_.forEach(choices, function(choice, index) {
+			_.forEach(choices, (choice, index) => {
 				index = index + 1;
 
 				if (index % 2 == 0) {
@@ -567,8 +567,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_getRowNumber', function() {
-		it('should return next row number for labels and messages', function() {
+	describe('_getRowNumber', () => {
+		it('should return next row number for labels and messages', () => {
 			prototype.rows = [1, 2];
 
 			var rowNumber = prototype._getRowNumber();
@@ -583,8 +583,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_preprocessLayoutTemplateData', function() {
-		it('should convert prompt data to data that template can easily process', function() {
+	describe('_preprocessLayoutTemplateData', () => {
+		it('should convert prompt data to data that template can easily process', () => {
 			var rows = [
 				{
 					0: 2,
@@ -619,10 +619,10 @@ describe('LayoutCreator', function() {
 
 			var number = 0;
 
-			_.forEach(rowDataFromObjects, function(row) {
+			_.forEach(rowDataFromObjects, (row) => {
 				assert(_.isArray(row), 'each row is an array');
 
-				_.forEach(row, function(column) {
+				_.forEach(row, (column) => {
 					assert(_.isObject(column), 'each row is an array');
 
 					number++;
@@ -648,8 +648,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_printLayoutPreview', function() {
-		it('should print layout preview', function() {
+	describe('_printLayoutPreview', () => {
+		it('should print layout preview', () => {
 			prototype.rows = [[6, 6], [3, 3, 6]];
 
 			prototype._stdoutWrite = sinon.spy();
@@ -674,8 +674,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptColumnCount', function() {
-		it('should prompt user for column count using correct row number in prompt message', function() {
+	describe('_promptColumnCount', () => {
+		it('should prompt user for column count using correct row number in prompt message', () => {
 			prototype.prompt = sinon.spy();
 
 			prototype.rows = [];
@@ -710,8 +710,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptColumnWidths', function() {
-		it('should prompt user for column widths', function() {
+	describe('_promptColumnWidths', () => {
+		it('should prompt user for column widths', () => {
 			prototype.prompt = sinon.spy();
 			prototype.rows = [];
 
@@ -732,7 +732,7 @@ describe('LayoutCreator', function() {
 				'it creates a question for every column'
 			);
 
-			_.forEach(questions, function(question, index) {
+			_.forEach(questions, (question, index) => {
 				var columnNumber = index + 1;
 
 				assert.equal(index, question.name, 'name is index');
@@ -745,8 +745,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptFinishRow', function() {
-		it('should prompt user for next action (add, insert, remove, finish)', function() {
+	describe('_promptFinishRow', () => {
+		it('should prompt user for next action (add, insert, remove, finish)', () => {
 			assertPromptFn(prototype, '_promptFinishRow', [[], _.noop], {
 				message: 'What now?',
 				name: 'finish',
@@ -754,8 +754,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptInsertRow', function() {
-		it('should prompt user for where they want to insert row', function() {
+	describe('_promptInsertRow', () => {
+		it('should prompt user for where they want to insert row', () => {
 			assertPromptFn(prototype, '_promptInsertRow', [_.noop], {
 				message: 'Where would you like to insert a new row?',
 				name: 'rowIndex',
@@ -763,8 +763,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptRemoveRow', function() {
-		it('should prompt user for what row they want to remove', function() {
+	describe('_promptRemoveRow', () => {
+		it('should prompt user for what row they want to remove', () => {
 			assertPromptFn(prototype, '_promptRemoveRow', [_.noop], {
 				message: 'What row would you like to remove?',
 				name: 'rowIndex',
@@ -772,8 +772,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_promptRow', function() {
-		it('should remove last row and print layout', function(done) {
+	describe('_promptRow', () => {
+		it('should remove last row and print layout', (done) => {
 			var waterfallSpy = sinon.spy();
 
 			var getWaterfallFunction = function(name) {
@@ -798,7 +798,7 @@ describe('LayoutCreator', function() {
 				'_promptFinishRow'
 			);
 
-			prototype._promptRow(function() {
+			prototype._promptRow(() => {
 				sinonAssert.calledWith(
 					waterfallSpy.getCall(0),
 					'_promptColumnCount'
@@ -819,8 +819,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_removeRow', function() {
-		it('should remove row by index and print layout', function() {
+	describe('_removeRow', () => {
+		it('should remove row by index and print layout', () => {
 			prototype._printLayoutPreview = sinon.spy();
 			prototype.rows = [1, 2, 3];
 
@@ -836,8 +836,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_renderPreviewLine', function() {
-		it('should render preview line', function() {
+	describe('_renderPreviewLine', () => {
+		it('should render preview line', () => {
 			var line = prototype._renderPreviewLine({
 				0: 4,
 				1: 8,
@@ -865,8 +865,8 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_renderLayoutTemplate', function() {
-		it('should compile data into valid template', function() {
+	describe('_renderLayoutTemplate', () => {
+		it('should compile data into valid template', () => {
 			var fileOptions = {
 				encoding: 'utf8',
 			};
@@ -901,22 +901,22 @@ describe('LayoutCreator', function() {
 		});
 	});
 
-	describe('_replaceAt', function() {
-		it('should replace string character at index', function() {
+	describe('_replaceAt', () => {
+		it('should replace string character at index', () => {
 			assert.equal(prototype._replaceAt('string', 0, 'x'), 'xtring');
 			assert.equal(prototype._replaceAt('string', 2, 'x'), 'stxing');
 			assert.equal(prototype._replaceAt('string', 6, 'x'), 'stringx');
 		});
 	});
 
-	describe('_stylePreviewLine', function() {
-		it('passes', function() {
+	describe('_stylePreviewLine', () => {
+		it('passes', () => {
 			expect(() => prototype._stylePreviewLine).not.toThrow();
 		});
 	});
 
-	describe('_validateColumnCount', function() {
-		it('should validate column count', function() {
+	describe('_validateColumnCount', () => {
+		it('should validate column count', () => {
 			var errMessage = 'Please enter a number between 1 and 12!';
 
 			var retVal = prototype._validateColumnCount(1);

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -150,12 +150,12 @@ describe('LayoutCreator', () => {
 			prototype.rows = [
 				[
 					{
-						size: 6,
 						columnNumber: 1,
+						size: 6,
 					},
 					{
-						size: 6,
 						columnNumber: 2,
+						size: 6,
 					},
 				],
 			];

--- a/packages/generator-liferay-theme/lib/layout_creator.js
+++ b/packages/generator-liferay-theme/lib/layout_creator.js
@@ -68,27 +68,6 @@ var LayoutCreator = function(options) {
 };
 
 LayoutCreator.prototype = {
-	init() {
-		if (this.rowData) {
-			this.after(
-				this._renderLayoutTemplate({
-					className: this.className,
-					rowData: this.rowData,
-				})
-			);
-		} else {
-			this.rows = [];
-
-			this._printHelpMessage();
-
-			this._promptRow(this._afterPrompt.bind(this));
-		}
-	},
-
-	prompt(questions, cb) {
-		inquirer.prompt(questions, cb);
-	},
-
 	_addRow(data) {
 		var rowInsertIndex = this.rowInsertIndex;
 
@@ -582,6 +561,15 @@ LayoutCreator.prototype = {
 		this._printLayoutPreview();
 	},
 
+	_renderLayoutTemplate(options) {
+		return layoutTemplateTpl(
+			_.defaults(options, {
+				columnPrefix: 'col-md-',
+				rowClassName: 'row',
+			})
+		);
+	},
+
 	_renderPreviewLine(column, config) {
 		var instance = this;
 
@@ -618,15 +606,6 @@ LayoutCreator.prototype = {
 			: this._stylePreviewLine(line, label);
 	},
 
-	_renderLayoutTemplate(options) {
-		return layoutTemplateTpl(
-			_.defaults(options, {
-				columnPrefix: 'col-md-',
-				rowClassName: 'row',
-			})
-		);
-	},
-
 	_replaceAt(string, index, character) {
 		return (
 			string.substr(0, index) +
@@ -659,6 +638,27 @@ LayoutCreator.prototype = {
 		}
 
 		return retVal;
+	},
+
+	init() {
+		if (this.rowData) {
+			this.after(
+				this._renderLayoutTemplate({
+					className: this.className,
+					rowData: this.rowData,
+				})
+			);
+		} else {
+			this.rows = [];
+
+			this._printHelpMessage();
+
+			this._promptRow(this._afterPrompt.bind(this));
+		}
+	},
+
+	prompt(questions, cb) {
+		inquirer.prompt(questions, cb);
 	},
 };
 

--- a/packages/generator-liferay-theme/lib/layout_creator.js
+++ b/packages/generator-liferay-theme/lib/layout_creator.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-var _ = require('lodash');
 var async = require('async');
 var chalk = require('chalk');
 var fs = require('fs');
 var inquirer = require('inquirer');
+var _ = require('lodash');
 var path = require('path');
 
 var templateString = fs.readFileSync(
@@ -29,7 +29,7 @@ inquirer.prompt.prompts.list.prototype.render = function() {
 
 	var choices = _.reduce(
 		this.opt.choices.choices,
-		function(result, item) {
+		(result, item) => {
 			if (item.type != 'separator') {
 				result.push(item);
 			}
@@ -214,7 +214,7 @@ LayoutCreator.prototype = {
 		var takenWidth = 0;
 		var totalWidth = 12;
 
-		_.forEach(answers, function(item) {
+		_.forEach(answers, (item) => {
 			item = _.parseInt(item);
 
 			takenWidth = takenWidth + item;
@@ -247,7 +247,7 @@ LayoutCreator.prototype = {
 
 			availableWidth = availableWidth - remainingColumns;
 
-			var choices = _.times(availableWidth, function(index) {
+			var choices = _.times(availableWidth, (index) => {
 				var spanValue = index + 1;
 
 				var selectedName = instance._formatPercentageValue(
@@ -309,7 +309,7 @@ LayoutCreator.prototype = {
 
 		var choicesArray = _.reduce(
 			this.rows,
-			function(choices, row, index) {
+			(choices, row, index) => {
 				choices.push({
 					name: insertName,
 					selectedName: insertSelectedName,
@@ -358,7 +358,7 @@ LayoutCreator.prototype = {
 
 		var choicesArray = _.reduce(
 			this.rows,
-			function(choices, row, index) {
+			(choices, row, index) => {
 				choices.push(new inquirer.Separator(seperator));
 
 				choices.push({
@@ -414,10 +414,10 @@ LayoutCreator.prototype = {
 
 		var totalColumnCount = 0;
 
-		var rowData = _.map(rows, function(row) {
+		var rowData = _.map(rows, (row) => {
 			var columnCount = _.size(row);
 
-			return _.map(row, function(size, index) {
+			return _.map(row, (size, index) => {
 				var columnNumber = _.parseInt(index) + 1;
 
 				totalColumnCount++;
@@ -457,7 +457,7 @@ LayoutCreator.prototype = {
 
 		var preview =
 			rowSeperator +
-			_.map(this.rows, function(item) {
+			_.map(this.rows, (item) => {
 				return (
 					instance._renderPreviewLine(item, {
 						label: true,
@@ -500,7 +500,7 @@ LayoutCreator.prototype = {
 
 		var rowNumber = instance._getRowNumber();
 
-		var questions = _.times(columnCount, function(index) {
+		var questions = _.times(columnCount, (index) => {
 			var columnNumber = index + 1;
 
 			return {
@@ -593,7 +593,7 @@ LayoutCreator.prototype = {
 
 		var width = 0;
 
-		_.forEach(column, function(columnWidth) {
+		_.forEach(column, (columnWidth) => {
 			var prevWidth = width;
 
 			width = width + columnWidth * 3;
@@ -641,7 +641,7 @@ LayoutCreator.prototype = {
 
 	_stylePreviewLine(line, label) {
 		if (label) {
-			line = line.replace(/\d/g, function(match) {
+			line = line.replace(/\d/g, (match) => {
 				return chalk.cyan(match);
 			});
 		}

--- a/packages/generator-liferay-theme/lib/layout_creator.js
+++ b/packages/generator-liferay-theme/lib/layout_creator.js
@@ -193,7 +193,7 @@ LayoutCreator.prototype = {
 		var takenWidth = 0;
 		var totalWidth = 12;
 
-		_.forEach(answers, (item) => {
+		_.forEach(answers, item => {
 			item = _.parseInt(item);
 
 			takenWidth = takenWidth + item;
@@ -226,7 +226,7 @@ LayoutCreator.prototype = {
 
 			availableWidth = availableWidth - remainingColumns;
 
-			var choices = _.times(availableWidth, (index) => {
+			var choices = _.times(availableWidth, index => {
 				var spanValue = index + 1;
 
 				var selectedName = instance._formatPercentageValue(
@@ -393,7 +393,7 @@ LayoutCreator.prototype = {
 
 		var totalColumnCount = 0;
 
-		var rowData = _.map(rows, (row) => {
+		var rowData = _.map(rows, row => {
 			var columnCount = _.size(row);
 
 			return _.map(row, (size, index) => {
@@ -436,7 +436,7 @@ LayoutCreator.prototype = {
 
 		var preview =
 			rowSeperator +
-			_.map(this.rows, (item) => {
+			_.map(this.rows, item => {
 				return (
 					instance._renderPreviewLine(item, {
 						label: true,
@@ -479,7 +479,7 @@ LayoutCreator.prototype = {
 
 		var rowNumber = instance._getRowNumber();
 
-		var questions = _.times(columnCount, (index) => {
+		var questions = _.times(columnCount, index => {
 			var columnNumber = index + 1;
 
 			return {
@@ -581,7 +581,7 @@ LayoutCreator.prototype = {
 
 		var width = 0;
 
-		_.forEach(column, (columnWidth) => {
+		_.forEach(column, columnWidth => {
 			var prevWidth = width;
 
 			width = width + columnWidth * 3;
@@ -620,7 +620,7 @@ LayoutCreator.prototype = {
 
 	_stylePreviewLine(line, label) {
 		if (label) {
-			line = line.replace(/\d/g, (match) => {
+			line = line.replace(/\d/g, match => {
 				return chalk.cyan(match);
 			});
 		}

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -8,13 +8,14 @@
 
 require('./lib/checkNodeVersion')();
 
-const _ = require('lodash');
 const globby = require('globby');
-const pluginTasks = require('./plugin');
+const _ = require('lodash');
 const path = require('path');
-const plugins = require('gulp-load-plugins')();
 
 const lfrThemeConfig = require('./lib/liferay_theme_config');
+const plugins = require('gulp-load-plugins')();
+
+const pluginTasks = require('./plugin');
 
 const themeConfig = lfrThemeConfig.getConfig();
 
@@ -46,7 +47,7 @@ function register(options) {
 
 	globby
 		.sync([path.resolve(__dirname, 'tasks/**/*')])
-		.forEach(function(item) {
+		.forEach((item) => {
 			if (item.indexOf('__tests__') == -1) {
 				require(item)(options);
 			}

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -47,6 +47,7 @@ function register(options) {
 
 	globby.sync([path.resolve(__dirname, 'tasks/**/*')]).forEach(item => {
 		if (item.indexOf('__tests__') == -1) {
+			// eslint-disable-next-line liferay/no-dynamic-require
 			require(item)(options);
 		}
 	});

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -45,11 +45,9 @@ function register(options) {
 
 	store.set('changedFile');
 
-	globby
-		.sync([path.resolve(__dirname, 'tasks/**/*')])
-		.forEach((item) => {
-			if (item.indexOf('__tests__') == -1) {
-				require(item)(options);
-			}
-		});
+	globby.sync([path.resolve(__dirname, 'tasks/**/*')]).forEach(item => {
+		if (item.indexOf('__tests__') == -1) {
+			require(item)(options);
+		}
+	});
 }

--- a/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const lfrThemeConfig = require('../liferay_theme_config.js');
 const testUtil = require('../../test/util');
+const lfrThemeConfig = require('../liferay_theme_config.js');
 
 const initCwd = process.cwd();
 

--- a/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const fs = require('fs-extra');
+const _ = require('lodash');
 const path = require('path');
 const sinon = require('sinon');
 
 const testUtil = require('../../test/util');
-
 const baseLookAndFeelJSON = require('./fixtures/look_and_feel_util/base-look-and-feel.json');
 const mixedLookAndFeelJSON = require('./fixtures/look_and_feel_util/mixed-look-and-feel.json');
 const parentLookAndFeelJSON = require('./fixtures/look_and_feel_util/parent-look-and-feel.json');

--- a/packages/liferay-theme-tasks/lib/__tests__/options.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/options.test.js
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {getArgv} = require('../util');
 const path = require('path');
+
+const {getArgv} = require('../util');
 
 const argv = getArgv();
 const initCwd = process.cwd();

--- a/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
+++ b/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
@@ -6,8 +6,8 @@
 
 'use strict';
 
-const bourbon = require('node-bourbon');
 const fs = require('fs-extra');
+const bourbon = require('node-bourbon');
 const path = require('path');
 
 const themeUtil = require('./util');

--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -18,12 +18,12 @@ function strict(version) {
 
 module.exports = {
 	default: {
-		gulp: '3.9.1',
-		'liferay-theme-tasks': '^9.4.0',
 		'compass-mixins': strict('0.12.10'),
+		gulp: '3.9.1',
 		'liferay-frontend-common-css': strict('1.0.4'),
 		'liferay-frontend-theme-styled': strict('4.0.7'),
 		'liferay-frontend-theme-unstyled': strict('4.0.4'),
+		'liferay-theme-tasks': '^9.4.0',
 	},
 	optional: {
 		'liferay-font-awesome': strict('3.4.0'),

--- a/packages/liferay-theme-tasks/lib/liferay_theme_config.js
+++ b/packages/liferay-theme-tasks/lib/liferay_theme_config.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const fs = require('fs-extra');
+const _ = require('lodash');
 const path = require('path');
 
 function getConfig(all) {
@@ -74,7 +74,7 @@ module.exports = {
 };
 
 function deleteDependencies(sourceDependencies, deletedDependencies) {
-	_.forEach(sourceDependencies, function(item, index) {
+	_.forEach(sourceDependencies, (item, index) => {
 		if (deletedDependencies.indexOf(index) > -1) {
 			delete sourceDependencies[index];
 		}

--- a/packages/liferay-theme-tasks/lib/liferay_theme_config.js
+++ b/packages/liferay-theme-tasks/lib/liferay_theme_config.js
@@ -6,7 +6,6 @@
 
 const fs = require('fs-extra');
 const _ = require('lodash');
-const path = require('path');
 
 function getConfig(all) {
 	const packageJSON = getPackageJSON();
@@ -82,7 +81,7 @@ function deleteDependencies(sourceDependencies, deletedDependencies) {
 }
 
 function getPackageJSON() {
-	return require(path.resolve('package.json'));
+	return JSON.parse(fs.readFileSync('package.json', 'utf8'));
 }
 
 function writePackageJSON(json) {

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const fs = require('fs-extra');
+const _ = require('lodash');
 const path = require('path');
 const util = require('util');
 const xml2js = require('xml2js');
@@ -49,7 +49,7 @@ function buildXML(lookAndFeelJSON, doctypeElement) {
 
 	themeElement = _.reduce(
 		THEME_CHILD_ORDER,
-		function(result, item) {
+		(result, item) => {
 			if (themeElement[item]) {
 				result[item] = themeElement[item];
 			}
@@ -119,7 +119,7 @@ function getLookAndFeelJSON(themePath, cb) {
 		return cb();
 	}
 
-	xml2js.parseString(xmlString, function(err, result) {
+	xml2js.parseString(xmlString, (err, result) => {
 		if (err) {
 			throw err;
 		}
@@ -147,7 +147,7 @@ function getNameFromPluginPackageProperties(themePath) {
 }
 
 function mergeLookAndFeelJSON(themePath, lookAndFeelJSON, cb) {
-	getLookAndFeelJSON(themePath, function(json) {
+	getLookAndFeelJSON(themePath, (json) => {
 		if (_.isEmpty(lookAndFeelJSON)) {
 			lookAndFeelJSON = json;
 		} else if (json) {
@@ -221,7 +221,7 @@ function extractThemeElement(obj, key) {
 }
 
 function mergeJSON(themeObj, baseThemeObj) {
-	_.forEach(QUERY_ELEMENTS, function(item, index) {
+	_.forEach(QUERY_ELEMENTS, (item, index) => {
 		let mergedElement;
 		const queryString = 'look-and-feel.theme.0.' + index;
 
@@ -263,7 +263,7 @@ function mergeThemeElementById(themeElements, baseThemeElements, identifier) {
 
 	return _.reduce(
 		allElements,
-		function(result, item) {
+		(result, item) => {
 			const id = item.$[identifier];
 
 			if (elementIds.indexOf(id) < 0) {

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -154,6 +154,7 @@ function mergeLookAndFeelJSON(themePath, lookAndFeelJSON, cb) {
 			lookAndFeelJSON = mergeJSON(lookAndFeelJSON, json);
 		}
 
+		// eslint-disable-next-line liferay/no-dynamic-require
 		const themeInfo = require(path.join(themePath, 'package.json'))
 			.liferayTheme;
 

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -147,7 +147,7 @@ function getNameFromPluginPackageProperties(themePath) {
 }
 
 function mergeLookAndFeelJSON(themePath, lookAndFeelJSON, cb) {
-	getLookAndFeelJSON(themePath, (json) => {
+	getLookAndFeelJSON(themePath, json => {
 		if (_.isEmpty(lookAndFeelJSON)) {
 			lookAndFeelJSON = json;
 		} else if (json) {

--- a/packages/liferay-theme-tasks/lib/normalize.js
+++ b/packages/liferay-theme-tasks/lib/normalize.js
@@ -17,7 +17,7 @@ function normalize(template) {
 	const replacementContent = '<!-- inject:js -->\n<!-- endinject -->\n\n';
 
 	if (template.indexOf(replacementContent) === -1) {
-		template = template.replace(beforeRegex, (match) => {
+		template = template.replace(beforeRegex, match => {
 			return replacementContent + match;
 		});
 	}

--- a/packages/liferay-theme-tasks/lib/normalize.js
+++ b/packages/liferay-theme-tasks/lib/normalize.js
@@ -17,7 +17,7 @@ function normalize(template) {
 	const replacementContent = '<!-- inject:js -->\n<!-- endinject -->\n\n';
 
 	if (template.indexOf(replacementContent) === -1) {
-		template = template.replace(beforeRegex, function(match) {
+		template = template.replace(beforeRegex, (match) => {
 			return replacementContent + match;
 		});
 	}

--- a/packages/liferay-theme-tasks/lib/options.js
+++ b/packages/liferay-theme-tasks/lib/options.js
@@ -5,9 +5,9 @@
  */
 
 const _ = require('lodash');
-const {getArgv} = require('./util');
 
 const lfrThemeConfig = require('./liferay_theme_config');
+const {getArgv} = require('./util');
 
 let options;
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -21,21 +21,21 @@ const liferayThemeThemletMetaData = {
 };
 const themeletDependencies = {
 	'themelet-1': {
+		__realPath__: 'path/to/themelet-1',
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-1',
-		__realPath__: 'path/to/themelet-1',
 		version: liferayVersion,
 	},
 	'themelet-2': {
+		__realPath__: 'path/to/themelet-2',
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-2',
-		__realPath__: 'path/to/themelet-2',
 		version: liferayVersion,
 	},
 	'themelet-3': {
+		__realPath__: 'path/to/themelet-3',
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-3',
-		__realPath__: 'path/to/themelet-3',
 		version: liferayVersion,
 	},
 };
@@ -99,8 +99,8 @@ it('_afterPromptTheme should save and install new dependencies', () => {
 					baseTheme: 'styled',
 					screenshot: '',
 					templateLanguage: 'ftl',
-					version: '7.0',
 					themeletDependencies: {},
+					version: '7.0',
 				},
 				name: 'some-theme',
 				publishConfig: {
@@ -297,12 +297,12 @@ it('_getDependencyInstallationArray should return paths, URLs or names', () => {
 			version: '1.0',
 		},
 		'themelet-2': {
+			__realPath__: 'path/to/themelet-2',
 			liferayTheme: {
 				themelet: true,
 				version: '*',
 			},
 			name: 'themelet-2',
-			__realPath__: 'path/to/themelet-2',
 			version: '1.0',
 		},
 		'themelet-3': {
@@ -317,12 +317,12 @@ it('_getDependencyInstallationArray should return paths, URLs or names', () => {
 			version: '1.0',
 		},
 		'themelet-4': {
+			__packageURL__: 'https://registry.example.org/themelet-4-1.0.0.tgz',
 			liferayTheme: {
 				themelet: true,
 				version: '7.0',
 			},
 			name: 'themelet-4',
-			__packageURL__: 'https://registry.example.org/themelet-4-1.0.0.tgz',
 			version: '1.0',
 		},
 	});
@@ -454,11 +454,11 @@ it('_reducePkgData should reduce package data to specified set of properties', (
 	const originalData = {
 		liferayTheme: '7.0',
 		name: 'name',
-		version: '1.1.1',
 		publishConfig: {
 			tag: 'tag',
 		},
 		someProp: 'some-value',
+		version: '1.1.1',
 	};
 
 	let pkgData = prototype._reducePkgData(originalData);

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -7,8 +7,8 @@
 const _ = require('lodash');
 const sinon = require('sinon');
 
-const lfrThemeConfig = require('../../liferay_theme_config.js');
 const testUtil = require('../../../test/util.js');
+const lfrThemeConfig = require('../../liferay_theme_config.js');
 
 const assertBoundFunction = testUtil.assertBoundFunction;
 const prototypeMethodSpy = new testUtil.PrototypeMethodSpy();

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 const path = require('path');
 const sinon = require('sinon');
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 const sinon = require('sinon');
 
 const testUtil = require('../../../test/util.js');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 const sinon = require('sinon');
 
 const testUtil = require('../../../test/util.js');

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -15,15 +15,15 @@ const liferayThemeThemletMetaData = {
 };
 const themeletDependencies = {
 	'themelet-1': {
+		__realPath__: 'path/to/themelet-1',
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-1',
-		__realPath__: 'path/to/themelet-1',
 		version: liferayVersion,
 	},
 	'themelet-2': {
+		__realPath__: 'path/to/themelet-2',
 		liferayTheme: liferayThemeThemletMetaData,
 		name: 'themelet-2',
-		__realPath__: 'path/to/themelet-2',
 		version: liferayVersion,
 	},
 	'themelet-3': {

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -77,7 +77,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 		selectedModules: ['themelet-1'],
 	});
 
-	_.forEach(choices, function(item, index) {
+	_.forEach(choices, (item, index) => {
 		const number = index + 1;
 		const name = 'themelet-' + number;
 
@@ -92,7 +92,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 		themelet: true,
 	});
 
-	_.forEach(choices, function(item, index) {
+	_.forEach(choices, (item, index) => {
 		const number = index + 1;
 		const name = 'themelet-' + number;
 
@@ -105,7 +105,7 @@ it('getModuleChoices should get module choices that are appropriate for extend t
 		themelet: true,
 	});
 
-	_.forEach(choices, function(item, index) {
+	_.forEach(choices, (item, index) => {
 		const number = index + 1;
 		const name = 'themelet-' + number;
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -5,16 +5,16 @@
  */
 
 const spawn = require('cross-spawn');
-const _ = require('lodash');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 
-const GlobalModulePrompt = require('./global_module_prompt');
 const lfrThemeConfig = require('../liferay_theme_config');
-const NPMModulePrompt = require('./npm_module_prompt');
-const URLPackagePrompt = require('./url_package_prompt');
-const promptUtil = require('./prompt_util');
 const themeFinder = require('../theme_finder');
 const {getArgv} = require('../util');
+const GlobalModulePrompt = require('./global_module_prompt');
+const NPMModulePrompt = require('./npm_module_prompt');
+const promptUtil = require('./prompt_util');
+const URLPackagePrompt = require('./url_package_prompt');
 
 const moduleName = getArgv().name;
 
@@ -108,7 +108,7 @@ class ExtendPrompt {
 		const removedThemelets = answers.removedThemelets;
 
 		if (removedThemelets) {
-			_.forEach(removedThemelets, function(item) {
+			_.forEach(removedThemelets, (item) => {
 				delete reducedThemelets[item];
 			});
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -108,7 +108,7 @@ class ExtendPrompt {
 		const removedThemelets = answers.removedThemelets;
 
 		if (removedThemelets) {
-			_.forEach(removedThemelets, (item) => {
+			_.forEach(removedThemelets, item => {
 				delete reducedThemelets[item];
 			});
 

--- a/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
+const _ = require('lodash');
 
-const ModulePrompt = require('./module_prompt');
 const themeFinder = require('../theme_finder');
+const ModulePrompt = require('./module_prompt');
 
 class GlobalModulePrompt {
 	constructor(...args) {

--- a/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const inquirer = require('inquirer');
+const _ = require('lodash');
 
 const promptUtil = require('./prompt_util');
 
@@ -41,7 +41,7 @@ class ModulePrompt {
 
 	_filterModule(input) {
 		if (this.themelet) {
-			return _.mapValues(this.modules, function(theme, name) {
+			return _.mapValues(this.modules, (theme, name) => {
 				return input.indexOf(name) > -1;
 			});
 		}

--- a/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
-const inquirer = require('inquirer');
 const log = require('fancy-log');
+const inquirer = require('inquirer');
+const _ = require('lodash');
 
-const ModulePrompt = require('./module_prompt');
 const themeFinder = require('../theme_finder');
+const ModulePrompt = require('./module_prompt');
 
 class NPMModulePrompt {
 	constructor(...args) {

--- a/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
+++ b/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
@@ -40,7 +40,7 @@ function formatThemeletSelection(modules, selectedModules) {
 
 	formattedSelection.addedThemelets = _.reduce(
 		modules,
-		function(result, selected, name) {
+		(result, selected, name) => {
 			if (selected && selectedModules.indexOf(name) < 0) {
 				result.push(name);
 			}

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -46,7 +46,7 @@ class URLPackagePrompt {
 		);
 		answers.module = config.name;
 		answers.modules = {
-			[config.name]: { ...config, __packageURL__: answers.packageURL,},
+			[config.name]: {...config, __packageURL__: answers.packageURL},
 		};
 		this.done(answers);
 	}

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -46,9 +46,7 @@ class URLPackagePrompt {
 		);
 		answers.module = config.name;
 		answers.modules = {
-			[config.name]: Object.assign({}, config, {
-				__packageURL__: answers.packageURL,
-			}),
+			[config.name]: { ...config, __packageURL__: answers.packageURL,},
 		};
 		this.done(answers);
 	}

--- a/packages/liferay-theme-tasks/lib/status.js
+++ b/packages/liferay-theme-tasks/lib/status.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
+const _ = require('lodash');
 
 function status(themeConfig) {
 	const statusBuffer = [];
@@ -35,7 +35,7 @@ function status(themeConfig) {
 	if (themeletDependencies) {
 		statusBuffer.push(colors.cyan('Themelets:'));
 
-		_.forEach(themeletDependencies, function(item) {
+		_.forEach(themeletDependencies, (item) => {
 			statusBuffer.push(
 				' - ' + colors.green(item.name + ' v' + item.version)
 			);

--- a/packages/liferay-theme-tasks/lib/status.js
+++ b/packages/liferay-theme-tasks/lib/status.js
@@ -35,7 +35,7 @@ function status(themeConfig) {
 	if (themeletDependencies) {
 		statusBuffer.push(colors.cyan('Themelets:'));
 
-		_.forEach(themeletDependencies, (item) => {
+		_.forEach(themeletDependencies, item => {
 			statusBuffer.push(
 				' - ' + colors.green(item.name + ' v' + item.version)
 			);

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -283,11 +283,11 @@ function getPackageJSON(theme, cb) {
 }
 
 const LiferayThemeModuleStatus = {
-	NO_PACKAGE_JSON: 'NO_PACKAGE_JSON',
 	NO_LIFERAY_THEME: 'NO_LIFERAY_THEME',
+	NO_PACKAGE_JSON: 'NO_PACKAGE_JSON',
+	OK: 'OK',
 	TARGET_VERSION_DOES_NOT_MATCH: 'TARGET_VERSION_DOES_NOT_MATCH',
 	THEMELET_FLAG_DOES_NOT_MATCH: 'THEMELET_FLAG_DOES_NOT_MATCH',
-	OK: 'OK',
 };
 
 function getLiferayThemeModuleStatus(pkg, themelet) {

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const async = require('async');
+const spawn = require('cross-spawn');
 const fs = require('fs');
 const globby = require('globby');
+const _ = require('lodash');
 const npmKeyword = require('npm-keyword');
 const os = require('os');
 const packageJson = require('package-json');
 const path = require('path');
-const spawn = require('cross-spawn');
 const {URL} = require('url');
 
 const lfrThemeConfig = require('./liferay_theme_config');

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -365,6 +365,7 @@ function searchGlobalModules(config, cb) {
 		modules,
 		(result, item) => {
 			try {
+				// eslint-disable-next-line liferay/no-dynamic-require
 				const json = require(path.join(item, 'package.json'));
 
 				json.__realPath__ = item;

--- a/packages/liferay-theme-tasks/lib/theme_inspector.js
+++ b/packages/liferay-theme-tasks/lib/theme_inspector.js
@@ -26,6 +26,7 @@ function getBaseThemeGlob(themePath) {
 }
 
 function getLiferayThemeJSON(themePath) {
+	// eslint-disable-next-line liferay/no-dynamic-require
 	return require(path.join(themePath, 'package.json')).liferayTheme;
 }
 

--- a/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
+const spawn = require('cross-spawn');
 const insert = require('gulp-insert');
 const replace = require('gulp-replace-task');
-const spawn = require('cross-spawn');
 
 const devDependencies = require('../../devDependencies');
 const lfrThemeConfig = require('../../liferay_theme_config');
@@ -18,7 +18,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('upgrade:dependencies', function(cb) {
+	gulp.task('upgrade:dependencies', (cb) => {
 		lfrThemeConfig.removeDependencies(['liferay-theme-deps-7.1']);
 		lfrThemeConfig.setDependencies(devDependencies.default, true);
 
@@ -42,7 +42,7 @@ module.exports = function(options) {
 		npmInstall.on('close', cb);
 	});
 
-	gulp.task('upgrade:config', function() {
+	gulp.task('upgrade:config', () => {
 		const lfrThemeConfig = require('../../liferay_theme_config.js');
 
 		lfrThemeConfig.setConfig({
@@ -79,7 +79,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest('src/WEB-INF'));
 	});
 
-	gulp.task('upgrade:fontAwesome', function() {
+	gulp.task('upgrade:fontAwesome', () => {
 		return gulp
 			.src('src/css/_custom.scss')
 			.pipe(

--- a/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('upgrade:dependencies', (cb) => {
+	gulp.task('upgrade:dependencies', cb => {
 		lfrThemeConfig.removeDependencies(['liferay-theme-deps-7.1']);
 		lfrThemeConfig.setDependencies(devDependencies.default, true);
 

--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -27,8 +27,8 @@ describe('config', () => {
 	beforeEach(() => {
 		const config = testUtil.copyTempTheme({
 			namespace: 'upgrade_task_config',
-			themeName: 'base-theme',
 			registerTasksOptions: {},
+			themeName: 'base-theme',
 		});
 
 		runSequence = config.runSequence;

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
 const spawn = require('cross-spawn');
 const es = require('event-stream');
-const fs = require('fs-extra');
 const log = require('fancy-log');
+const fs = require('fs-extra');
+const _ = require('lodash');
 const minimist = require('minimist');
 const path = require('path');
 const tar = require('tar-fs');
@@ -59,7 +59,7 @@ function dockerCopy(containerName, sourceFolder, destFolder, sourceFiles, cb) {
 	}
 
 	tar.pack(sourceFolder, packConfig).pipe(
-		es.wait(function(err, body) {
+		es.wait((err, body) => {
 			if (err) throw err;
 
 			const proc = spawn.sync(

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -26,8 +26,8 @@ const CUSTOM_DEP_PATH_FLAG_MAP = {
 };
 
 const DEPLOYMENT_STRATEGIES = {
-	LOCAL_APP_SERVER: 'LocalAppServer',
 	DOCKER_CONTAINER: 'DockerContainer',
+	LOCAL_APP_SERVER: 'LocalAppServer',
 	OTHER: 'Other',
 };
 

--- a/packages/liferay-theme-tasks/lib/war_deployer.js
+++ b/packages/liferay-theme-tasks/lib/war_deployer.js
@@ -101,6 +101,7 @@ class WarDeployer extends EventEmitter {
 	}
 
 	_makeRequest() {
+		// eslint-disable-next-line liferay/no-dynamic-require
 		const protocol = require(this.protocol);
 
 		const req = protocol.request(this._getPostOptions(), res => {

--- a/packages/liferay-theme-tasks/lib/war_deployer.js
+++ b/packages/liferay-theme-tasks/lib/war_deployer.js
@@ -5,11 +5,12 @@
  */
 
 const EventEmitter = require('events').EventEmitter;
-const _ = require('lodash');
+
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 const fs = require('fs');
 const inquirer = require('inquirer');
-const log = require('fancy-log');
+const _ = require('lodash');
 const path = require('path');
 const url = require('url');
 

--- a/packages/liferay-theme-tasks/plugin/index.js
+++ b/packages/liferay-theme-tasks/plugin/index.js
@@ -33,7 +33,7 @@ module.exports.registerTasks = function(options) {
 
 	var tasks = require('./tasks/index');
 
-	_.forEach(tasks, (task) => {
+	_.forEach(tasks, task => {
 		task(options);
 	});
 
@@ -42,7 +42,7 @@ module.exports.registerTasks = function(options) {
 			options.extensions = [options.extensions];
 		}
 
-		_.forEach(options.extensions, (extension) => {
+		_.forEach(options.extensions, extension => {
 			extension(options);
 		});
 	}

--- a/packages/liferay-theme-tasks/plugin/index.js
+++ b/packages/liferay-theme-tasks/plugin/index.js
@@ -6,10 +6,10 @@
 
 'use strict';
 
-var _ = require('lodash');
 var help = require('gulp-help');
-var path = require('path');
 var storage = require('gulp-storage');
+var _ = require('lodash');
+var path = require('path');
 
 var RegisterHooks = require('./lib/register_hooks');
 
@@ -33,7 +33,7 @@ module.exports.registerTasks = function(options) {
 
 	var tasks = require('./tasks/index');
 
-	_.forEach(tasks, function(task) {
+	_.forEach(tasks, (task) => {
 		task(options);
 	});
 
@@ -42,7 +42,7 @@ module.exports.registerTasks = function(options) {
 			options.extensions = [options.extensions];
 		}
 
-		_.forEach(options.extensions, function(extension) {
+		_.forEach(options.extensions, (extension) => {
 			extension(options);
 		});
 	}

--- a/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-var _ = require('lodash');
 var fs = require('fs');
 var inquirer = require('inquirer');
+var _ = require('lodash');
 var path = require('path');
 var util = require('util');
 
@@ -76,7 +76,7 @@ InitPrompt.prototype = {
 
 			var done = this.async();
 
-			fs.stat(deployPath, function(err, stats) {
+			fs.stat(deployPath, (err, stats) => {
 				var ask = err || !stats.isDirectory();
 
 				if (!ask) {

--- a/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
@@ -58,10 +58,6 @@ InitPrompt.prototype = {
 		);
 	},
 
-	_dockerContainerNameWhen(answers) {
-		return isDocker(answers);
-	},
-
 	_deployPathWhen(answers) {
 		if (isDocker(answers)) {
 			return true;
@@ -86,6 +82,10 @@ InitPrompt.prototype = {
 				done(ask);
 			});
 		}
+	},
+
+	_dockerContainerNameWhen(answers) {
+		return isDocker(answers);
 	},
 
 	_getDefaultDeployPath(answers) {
@@ -125,7 +125,6 @@ InitPrompt.prototype = {
 		inquirer.prompt(
 			[
 				{
-					default: DEFAULT_DEPLOYMENT_STRATEGY,
 					choices: [
 						{
 							name: 'Local App Server',
@@ -140,8 +139,9 @@ InitPrompt.prototype = {
 							value: DEPLOYMENT_STRATEGY_OTHER,
 						},
 					],
-					name: 'deploymentStrategy',
+					default: DEFAULT_DEPLOYMENT_STRATEGY,
 					message: 'Select your deployment strategy',
+					name: 'deploymentStrategy',
 					type: 'list',
 				},
 				{

--- a/packages/liferay-theme-tasks/plugin/lib/options.js
+++ b/packages/liferay-theme-tasks/plugin/lib/options.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const fs = require('fs');
 var _ = require('lodash');
 var path = require('path');
 
@@ -21,7 +22,9 @@ module.exports = function(options) {
 	var pkg;
 
 	try {
-		pkg = require(path.join(CWD, 'package.json'));
+		pkg = JSON.parse(
+			fs.readFileSync(path.join(CWD, 'package.json'), 'utf8')
+		);
 
 		distName = pkg.name;
 	} catch (e) {

--- a/packages/liferay-theme-tasks/plugin/lib/options.js
+++ b/packages/liferay-theme-tasks/plugin/lib/options.js
@@ -8,6 +8,7 @@
 
 var _ = require('lodash');
 var path = require('path');
+
 var {getArgv} = require('../../lib/util');
 
 module.exports = function(options) {

--- a/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
@@ -138,6 +138,7 @@ RegisterHooks.prototype = {
 
 	_registerHookModule(moduleName) {
 		try {
+			// eslint-disable-next-line liferay/no-dynamic-require
 			var hookFn = require(moduleName);
 
 			if (_.isFunction(hookFn)) {

--- a/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-var _ = require('lodash');
 var async = require('async');
 var gutil = require('gulp-util');
+var _ = require('lodash');
 
 var chalk = gutil.colors;
 
@@ -29,7 +29,7 @@ RegisterHooks.hook = function(gulp, config) {
 RegisterHooks.prototype = {
 	_addToSequence(sequence, fn) {
 		if (_.isFunction(fn)) {
-			sequence.push(function(cb) {
+			sequence.push((cb) => {
 				if (fn.length) {
 					fn(cb);
 				} else {
@@ -54,7 +54,7 @@ RegisterHooks.prototype = {
 
 		var tasks = gulp.tasks;
 
-		_.forEach(taskHookMap, function(hooks, taskName) {
+		_.forEach(taskHookMap, (hooks, taskName) => {
 			if (!tasks[taskName]) {
 				return;
 			}
@@ -63,7 +63,7 @@ RegisterHooks.prototype = {
 
 			var sequence = instance._createTaskSequence(task.fn, hooks);
 
-			gulp.task(taskName, task.dep, function(cb) {
+			gulp.task(taskName, task.dep, (cb) => {
 				async.series(sequence, cb);
 			});
 		});
@@ -74,13 +74,13 @@ RegisterHooks.prototype = {
 
 		var sequence = [];
 
-		_.forEach(hooks.before, function(hookFn) {
+		_.forEach(hooks.before, (hookFn) => {
 			instance._addToSequence(sequence, hookFn);
 		});
 
 		this._addToSequence(sequence, fn);
 
-		_.forEach(hooks.after, function(hookFn) {
+		_.forEach(hooks.after, (hookFn) => {
 			instance._addToSequence(sequence, hookFn);
 		});
 
@@ -94,7 +94,7 @@ RegisterHooks.prototype = {
 
 		return _.reduce(
 			hooks,
-			function(taskHookMap, hook, name) {
+			(taskHookMap, hook, name) => {
 				var data = instance._getTaskName(name);
 
 				var when = data[0];

--- a/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
@@ -29,7 +29,7 @@ RegisterHooks.hook = function(gulp, config) {
 RegisterHooks.prototype = {
 	_addToSequence(sequence, fn) {
 		if (_.isFunction(fn)) {
-			sequence.push((cb) => {
+			sequence.push(cb => {
 				if (fn.length) {
 					fn(cb);
 				} else {
@@ -63,7 +63,7 @@ RegisterHooks.prototype = {
 
 			var sequence = instance._createTaskSequence(task.fn, hooks);
 
-			gulp.task(taskName, task.dep, (cb) => {
+			gulp.task(taskName, task.dep, cb => {
 				async.series(sequence, cb);
 			});
 		});
@@ -74,13 +74,13 @@ RegisterHooks.prototype = {
 
 		var sequence = [];
 
-		_.forEach(hooks.before, (hookFn) => {
+		_.forEach(hooks.before, hookFn => {
 			instance._addToSequence(sequence, hookFn);
 		});
 
 		this._addToSequence(sequence, fn);
 
-		_.forEach(hooks.after, (hookFn) => {
+		_.forEach(hooks.after, hookFn => {
 			instance._addToSequence(sequence, hookFn);
 		});
 

--- a/packages/liferay-theme-tasks/plugin/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/deploy.js
@@ -36,7 +36,7 @@ module.exports = function(options) {
 		return stream;
 	});
 
-	gulp.task('deploy', (cb) => {
+	gulp.task('deploy', cb => {
 		runSequence(TASK_BUILD, TASK_PLUGIN_DEPLOY, cb);
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/deploy.js
@@ -20,7 +20,7 @@ module.exports = function(options) {
 
 	var store = gulp.storage;
 
-	gulp.task(TASK_PLUGIN_DEPLOY, function() {
+	gulp.task(TASK_PLUGIN_DEPLOY, () => {
 		var deployPath = store.get('deployPath');
 
 		var stream = gulp
@@ -29,14 +29,14 @@ module.exports = function(options) {
 
 		gutil.log('Deploying to ' + gutil.colors.cyan(deployPath));
 
-		stream.on('end', function() {
+		stream.on('end', () => {
 			store.set('deployed', true);
 		});
 
 		return stream;
 	});
 
-	gulp.task('deploy', function(cb) {
+	gulp.task('deploy', (cb) => {
 		runSequence(TASK_BUILD, TASK_PLUGIN_DEPLOY, cb);
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/init.js
@@ -17,7 +17,7 @@ module.exports = function(options) {
 
 	var store = gulp.storage;
 
-	gulp.task(TASK_PLUGIN_INIT, (cb) => {
+	gulp.task(TASK_PLUGIN_INIT, cb => {
 		new InitPrompt(
 			{
 				appServerPathDefault:

--- a/packages/liferay-theme-tasks/plugin/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/init.js
@@ -6,8 +6,9 @@
 
 'use strict';
 
-var InitPrompt = require('../lib/init_prompt');
 var path = require('path');
+
+var InitPrompt = require('../lib/init_prompt');
 
 var TASK_PLUGIN_INIT = 'plugin:init';
 
@@ -16,7 +17,7 @@ module.exports = function(options) {
 
 	var store = gulp.storage;
 
-	gulp.task(TASK_PLUGIN_INIT, function(cb) {
+	gulp.task(TASK_PLUGIN_INIT, (cb) => {
 		new InitPrompt(
 			{
 				appServerPathDefault:

--- a/packages/liferay-theme-tasks/plugin/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/version.js
@@ -17,7 +17,7 @@ var REGEX_MODULE_VERSION = /module-version=([0-9.]+)/;
 module.exports = function(options) {
 	var gulp = options.gulp;
 
-	gulp.task('plugin:version', function(done) {
+	gulp.task('plugin:version', (done) => {
 		var npmPackageVersion = require(path.join(
 			process.cwd(),
 			'package.json'
@@ -34,7 +34,7 @@ module.exports = function(options) {
 			{
 				encoding: 'utf8',
 			},
-			function(err, result) {
+			(err, result) => {
 				if (err) {
 					throw err;
 				}
@@ -42,10 +42,10 @@ module.exports = function(options) {
 				var moduleVersion = result.match(REGEX_MODULE_VERSION);
 
 				if (moduleVersion && moduleVersion[1] != npmPackageVersion) {
-					result = result.replace(REGEX_MODULE_VERSION, function(
+					result = result.replace(REGEX_MODULE_VERSION, (
 						_match,
 						_g1
-					) {
+					) => {
 						return 'module-version=' + npmPackageVersion;
 					});
 

--- a/packages/liferay-theme-tasks/plugin/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/version.js
@@ -17,7 +17,7 @@ var REGEX_MODULE_VERSION = /module-version=([0-9.]+)/;
 module.exports = function(options) {
 	var gulp = options.gulp;
 
-	gulp.task('plugin:version', (done) => {
+	gulp.task('plugin:version', done => {
 		var npmPackageVersion = require(path.join(
 			process.cwd(),
 			'package.json'
@@ -42,12 +42,12 @@ module.exports = function(options) {
 				var moduleVersion = result.match(REGEX_MODULE_VERSION);
 
 				if (moduleVersion && moduleVersion[1] != npmPackageVersion) {
-					result = result.replace(REGEX_MODULE_VERSION, (
-						_match,
-						_g1
-					) => {
-						return 'module-version=' + npmPackageVersion;
-					});
+					result = result.replace(
+						REGEX_MODULE_VERSION,
+						(_match, _g1) => {
+							return 'module-version=' + npmPackageVersion;
+						}
+					);
 
 					logWarning();
 				} else if (!moduleVersion) {

--- a/packages/liferay-theme-tasks/plugin/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/version.js
@@ -18,10 +18,9 @@ module.exports = function(options) {
 	var gulp = options.gulp;
 
 	gulp.task('plugin:version', done => {
-		var npmPackageVersion = require(path.join(
-			process.cwd(),
-			'package.json'
-		)).version;
+		var npmPackageVersion = JSON.parse(
+			fs.readFileSync('package.json', 'utf8')
+		).version;
 
 		var pluginPackgePropertiesPath = path.join(
 			options.rootDir,

--- a/packages/liferay-theme-tasks/plugin/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/war.js
@@ -6,8 +6,8 @@
 
 'use strict';
 
-var path = require('path');
 var zip = require('gulp-zip');
+var path = require('path');
 
 var TASK_PLUGIN_WAR = 'plugin:war';
 
@@ -16,14 +16,14 @@ module.exports = function(options) {
 
 	var runSequence = require('run-sequence').use(gulp);
 
-	gulp.task(TASK_PLUGIN_WAR, function() {
+	gulp.task(TASK_PLUGIN_WAR, () => {
 		return gulp
 			.src(path.join(options.rootDir, '**/*'))
 			.pipe(zip(options.distName + '.war'))
 			.pipe(gulp.dest(options.pathDist));
 	});
 
-	gulp.task('build', function(done) {
+	gulp.task('build', (done) => {
 		runSequence('plugin:version', TASK_PLUGIN_WAR, done);
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/war.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest(options.pathDist));
 	});
 
-	gulp.task('build', (done) => {
+	gulp.task('build', done => {
 		runSequence('plugin:version', TASK_PLUGIN_WAR, done);
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
@@ -7,11 +7,11 @@
 var EventEmitter = require('events').EventEmitter;
 
 module.exports = function(gulp) {
-	gulp.hook('before:build', function() {
+	gulp.hook('before:build', () => {
 		var eventEmitter = new EventEmitter();
 
 		// Simulates the end of an async gulp stream
-		setTimeout(function() {
+		setTimeout(() => {
 			eventEmitter.emit('end');
 		}, 200);
 

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
@@ -5,7 +5,7 @@
  */
 
 module.exports = function(gulp) {
-	gulp.hook('after:build', function(cb) {
+	gulp.hook('after:build', (cb) => {
 		cb();
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
@@ -5,7 +5,7 @@
  */
 
 module.exports = function(gulp) {
-	gulp.hook('after:build', (cb) => {
+	gulp.hook('after:build', cb => {
 		cb();
 	});
 };

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -35,11 +35,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll((done) => {
+beforeAll(done => {
 	fs.copy(
 		path.join(__dirname, './fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		(err) => {
+		err => {
 			if (err) {
 				throw err;
 			}
@@ -65,7 +65,7 @@ beforeAll((done) => {
 	);
 });
 
-afterAll((done) => {
+afterAll(done => {
 	del([path.join(tempPath, '**')], {
 		force: true,
 	}).then(() => {
@@ -81,7 +81,7 @@ afterEach(() => {
 	});
 });
 
-test('registerTasks should invoke extension functions', (done) => {
+test('registerTasks should invoke extension functions', done => {
 	gulp = new Gulp();
 
 	var extFunction = function(options) {
@@ -107,7 +107,7 @@ test('registerTasks should invoke extension functions', (done) => {
 	});
 });
 
-test('registerTasks should accept array of extension function', (done) => {
+test('registerTasks should accept array of extension function', done => {
 	gulp = new Gulp();
 
 	var extFunction = function(options) {
@@ -122,25 +122,25 @@ test('registerTasks should accept array of extension function', (done) => {
 	});
 });
 
-test('registerTasks should register hooks', (done) => {
+test('registerTasks should register hooks', done => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', (cb) => {
+		gulp.hook('before:plugin:war', cb => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:plugin:war', (cb) => {
+		gulp.hook('after:plugin:war', cb => {
 			hookSpy('after:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:plugin:deploy', (cb) => {
+		gulp.hook('after:plugin:deploy', cb => {
 			hookSpy('after:plugin:deploy');
 
 			cb();
@@ -169,19 +169,19 @@ test('registerTasks should register hooks', (done) => {
 	});
 });
 
-test('registerTasks should register hooks for extension tasks', (done) => {
+test('registerTasks should register hooks for extension tasks', done => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', (cb) => {
+		gulp.hook('before:plugin:war', cb => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:my-custom:task', (cb) => {
+		gulp.hook('after:my-custom:task', cb => {
 			hookSpy('after:my-custom:task');
 
 			cb();
@@ -190,7 +190,7 @@ test('registerTasks should register hooks for extension tasks', (done) => {
 
 	registerTasks({
 		extensions(options) {
-			options.gulp.task('my-custom:task', (cb) => {
+			options.gulp.task('my-custom:task', cb => {
 				hookSpy('my-custom:task');
 
 				cb();
@@ -213,19 +213,19 @@ test('registerTasks should register hooks for extension tasks', (done) => {
 	});
 });
 
-test('registerTasks should overwrite task', (done) => {
+test('registerTasks should overwrite task', done => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', (cb) => {
+		gulp.hook('before:plugin:war', cb => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.task('plugin:war', (cb) => {
+		gulp.task('plugin:war', cb => {
 			hookSpy('plugin:war');
 
 			cb();
@@ -247,7 +247,7 @@ test('registerTasks should overwrite task', (done) => {
 	});
 });
 
-test('registerTasks should use distName as template if delimiters are present', (done) => {
+test('registerTasks should use distName as template if delimiters are present', done => {
 	gulp = new Gulp();
 
 	registerTasks({

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -10,6 +10,7 @@ var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var Gulp = require('gulp').Gulp;
+
 var os = require('os');
 var path = require('path');
 var sinon = require('sinon');
@@ -34,11 +35,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll(function(done) {
+beforeAll((done) => {
 	fs.copy(
 		path.join(__dirname, './fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		function(err) {
+		(err) => {
 			if (err) {
 				throw err;
 			}
@@ -64,23 +65,23 @@ beforeAll(function(done) {
 	);
 });
 
-afterAll(function(done) {
+afterAll((done) => {
 	del([path.join(tempPath, '**')], {
 		force: true,
-	}).then(function() {
+	}).then(() => {
 		process.chdir(initCwd);
 
 		done();
 	});
 });
 
-afterEach(function() {
+afterEach(() => {
 	del.sync(path.join(deployPath, '**'), {
 		force: true,
 	});
 });
 
-test('registerTasks should invoke extension functions', function(done) {
+test('registerTasks should invoke extension functions', (done) => {
 	gulp = new Gulp();
 
 	var extFunction = function(options) {
@@ -106,7 +107,7 @@ test('registerTasks should invoke extension functions', function(done) {
 	});
 });
 
-test('registerTasks should accept array of extension function', function(done) {
+test('registerTasks should accept array of extension function', (done) => {
 	gulp = new Gulp();
 
 	var extFunction = function(options) {
@@ -121,25 +122,25 @@ test('registerTasks should accept array of extension function', function(done) {
 	});
 });
 
-test('registerTasks should register hooks', function(done) {
+test('registerTasks should register hooks', (done) => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', function(cb) {
+		gulp.hook('before:plugin:war', (cb) => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:plugin:war', function(cb) {
+		gulp.hook('after:plugin:war', (cb) => {
 			hookSpy('after:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:plugin:deploy', function(cb) {
+		gulp.hook('after:plugin:deploy', (cb) => {
 			hookSpy('after:plugin:deploy');
 
 			cb();
@@ -155,7 +156,7 @@ test('registerTasks should register hooks', function(done) {
 
 	runSequence = require('run-sequence').use(gulp);
 
-	runSequence('plugin:war', 'plugin:deploy', function() {
+	runSequence('plugin:war', 'plugin:deploy', () => {
 		assert.isFile(path.join(deployPath, 'test-plugin-layouttpl.war'));
 
 		expect(gulp.storage.get('deployed')).toBe(true);
@@ -168,19 +169,19 @@ test('registerTasks should register hooks', function(done) {
 	});
 });
 
-test('registerTasks should register hooks for extension tasks', function(done) {
+test('registerTasks should register hooks for extension tasks', (done) => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', function(cb) {
+		gulp.hook('before:plugin:war', (cb) => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.hook('after:my-custom:task', function(cb) {
+		gulp.hook('after:my-custom:task', (cb) => {
 			hookSpy('after:my-custom:task');
 
 			cb();
@@ -189,7 +190,7 @@ test('registerTasks should register hooks for extension tasks', function(done) {
 
 	registerTasks({
 		extensions(options) {
-			options.gulp.task('my-custom:task', function(cb) {
+			options.gulp.task('my-custom:task', (cb) => {
 				hookSpy('my-custom:task');
 
 				cb();
@@ -201,7 +202,7 @@ test('registerTasks should register hooks for extension tasks', function(done) {
 
 	runSequence = require('run-sequence').use(gulp);
 
-	runSequence('plugin:war', 'my-custom:task', function() {
+	runSequence('plugin:war', 'my-custom:task', () => {
 		expect(hookSpy.getCall(0).calledWith('before:plugin:war')).toBe(true);
 		expect(hookSpy.getCall(1).calledWith('my-custom:task')).toBe(true);
 		expect(hookSpy.getCall(2).calledWith('after:my-custom:task')).toBe(
@@ -212,19 +213,19 @@ test('registerTasks should register hooks for extension tasks', function(done) {
 	});
 });
 
-test('registerTasks should overwrite task', function(done) {
+test('registerTasks should overwrite task', (done) => {
 	gulp = new Gulp();
 
 	var hookSpy = sinon.spy();
 
 	var hookFn = function(gulp) {
-		gulp.hook('before:plugin:war', function(cb) {
+		gulp.hook('before:plugin:war', (cb) => {
 			hookSpy('before:plugin:war');
 
 			cb();
 		});
 
-		gulp.task('plugin:war', function(cb) {
+		gulp.task('plugin:war', (cb) => {
 			hookSpy('plugin:war');
 
 			cb();
@@ -238,7 +239,7 @@ test('registerTasks should overwrite task', function(done) {
 
 	runSequence = require('run-sequence').use(gulp);
 
-	runSequence('plugin:war', function() {
+	runSequence('plugin:war', () => {
 		expect(hookSpy.getCall(0).calledWith('before:plugin:war')).toBe(true);
 		expect(hookSpy.getCall(1).calledWith('plugin:war')).toBe(true);
 
@@ -246,7 +247,7 @@ test('registerTasks should overwrite task', function(done) {
 	});
 });
 
-test('registerTasks should use distName as template if delimiters are present', function(done) {
+test('registerTasks should use distName as template if delimiters are present', (done) => {
 	gulp = new Gulp();
 
 	registerTasks({

--- a/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
@@ -23,21 +23,21 @@ function getDefaultAnswers() {
 	};
 }
 
-beforeAll(function() {
+beforeAll(() => {
 	process.chdir(path.join(__dirname, '../..'));
 
 	InitPrompt = require('../../lib/init_prompt');
 });
 
-afterAll(function() {
+afterAll(() => {
 	process.chdir(initCwd);
 });
 
-beforeEach(function() {
+beforeEach(() => {
 	prototype = _.create(InitPrompt.prototype);
 });
 
-test('_afterPrompt should store normalized answers', function() {
+test('_afterPrompt should store normalized answers', () => {
 	prototype.store = {
 		store: sinon.spy(),
 	};
@@ -65,7 +65,7 @@ test('_afterPrompt should store normalized answers', function() {
 	prototype._afterPrompt(defaultAnswers);
 });
 
-test('_deployPathWhen should return false and add deployPath to answers', function(done) {
+test('_deployPathWhen should return false and add deployPath to answers', (done) => {
 	var defaultAnswers = getDefaultAnswers();
 
 	var answers = {
@@ -84,7 +84,7 @@ test('_deployPathWhen should return false and add deployPath to answers', functi
 	prototype._deployPathWhen(answers);
 });
 
-test('_deployPathWhen should return true when deploy path is not a sibling with provided appServerPath', function(done) {
+test('_deployPathWhen should return true when deploy path is not a sibling with provided appServerPath', (done) => {
 	var defaultAnswers = getDefaultAnswers();
 
 	var answers = {
@@ -103,7 +103,7 @@ test('_deployPathWhen should return true when deploy path is not a sibling with 
 	prototype._deployPathWhen(answers);
 });
 
-test('_getDefaultDeployPath should return defualy deploy path value based on answers', function() {
+test('_getDefaultDeployPath should return defualy deploy path value based on answers', () => {
 	var defaultPath = prototype._getDefaultDeployPath({
 		appServerPath: '/path-to/appserver/tomcat',
 	});
@@ -111,7 +111,7 @@ test('_getDefaultDeployPath should return defualy deploy path value based on ans
 	expect(path.join('/path-to', 'appserver', 'deploy')).toBe(defaultPath);
 });
 
-test('_normalizeAnswers should normalize prompt answers', function() {
+test('_normalizeAnswers should normalize prompt answers', () => {
 	var defaultAnswers = getDefaultAnswers();
 	var answers = getDefaultAnswers();
 
@@ -138,7 +138,7 @@ test('_normalizeAnswers should normalize prompt answers', function() {
 	);
 });
 
-test('_prompt should invoke inquirer.prompt with correct args', function() {
+test('_prompt should invoke inquirer.prompt with correct args', () => {
 	var inquirer = require('inquirer');
 
 	var prompt = inquirer.prompt;
@@ -149,7 +149,7 @@ test('_prompt should invoke inquirer.prompt with correct args', function() {
 
 	var args = inquirer.prompt.args[0];
 
-	_.forEach(args[0], function(item) {
+	_.forEach(args[0], (item) => {
 		expect(_.isObject(item)).toBe(true);
 	});
 
@@ -158,7 +158,7 @@ test('_prompt should invoke inquirer.prompt with correct args', function() {
 	inquirer.prompt = prompt;
 });
 
-test('_validateAppServerPath should properly validate path and return appropriate messages if invalid', function() {
+test('_validateAppServerPath should properly validate path and return appropriate messages if invalid', () => {
 	var defaultAnswers = getDefaultAnswers();
 
 	var retVal = prototype._validateAppServerPath();

--- a/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
@@ -65,7 +65,7 @@ test('_afterPrompt should store normalized answers', () => {
 	prototype._afterPrompt(defaultAnswers);
 });
 
-test('_deployPathWhen should return false and add deployPath to answers', (done) => {
+test('_deployPathWhen should return false and add deployPath to answers', done => {
 	var defaultAnswers = getDefaultAnswers();
 
 	var answers = {
@@ -84,7 +84,7 @@ test('_deployPathWhen should return false and add deployPath to answers', (done)
 	prototype._deployPathWhen(answers);
 });
 
-test('_deployPathWhen should return true when deploy path is not a sibling with provided appServerPath', (done) => {
+test('_deployPathWhen should return true when deploy path is not a sibling with provided appServerPath', done => {
 	var defaultAnswers = getDefaultAnswers();
 
 	var answers = {
@@ -149,7 +149,7 @@ test('_prompt should invoke inquirer.prompt with correct args', () => {
 
 	var args = inquirer.prompt.args[0];
 
-	_.forEach(args[0], (item) => {
+	_.forEach(args[0], item => {
 		expect(_.isObject(item)).toBe(true);
 	});
 

--- a/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
@@ -6,11 +6,12 @@
 
 'use strict';
 
-var _ = require('lodash');
 var async = require('async');
+var gutil = require('gulp-util');
 var EventEmitter = require('events').EventEmitter;
 var Gulp = require('gulp').Gulp;
-var gutil = require('gulp-util');
+
+var _ = require('lodash');
 var path = require('path');
 var sinon = require('sinon');
 
@@ -20,25 +21,25 @@ var STR_NOT_A_FUNCTION = 'not a function';
 
 var prototype;
 
-beforeEach(function() {
+beforeEach(() => {
 	prototype = _.create(RegisterHooks.prototype);
 });
 
-test('_addToSequence should add function to sequence differently based on if cb is expected or stream is returned', function(done) {
+test('_addToSequence should add function to sequence differently based on if cb is expected or stream is returned', (done) => {
 	var sequence = [];
 
 	var spy = sinon.spy();
 
-	prototype._addToSequence(sequence, function(cb) {
+	prototype._addToSequence(sequence, (cb) => {
 		spy();
 
 		cb();
 	});
 
-	prototype._addToSequence(sequence, function() {
+	prototype._addToSequence(sequence, () => {
 		var eventEmitter = new EventEmitter();
 
-		setTimeout(function() {
+		setTimeout(() => {
 			spy();
 
 			eventEmitter.emit('end');
@@ -51,21 +52,21 @@ test('_addToSequence should add function to sequence differently based on if cb 
 
 	expect(sequence.length).toBe(2);
 
-	async.series(sequence, function() {
+	async.series(sequence, () => {
 		expect(spy.callCount).toBe(2);
 
 		done();
 	});
 });
 
-test('_applyHooks should pass', function() {
+test('_applyHooks should pass', () => {
 	prototype.gulp = new Gulp();
 
-	prototype.gulp.task('test', ['test2'], function(cb) {
+	prototype.gulp.task('test', ['test2'], (cb) => {
 		cb();
 	});
 
-	prototype.gulp.task('test2', function(cb) {
+	prototype.gulp.task('test2', (cb) => {
 		cb();
 	});
 
@@ -87,7 +88,7 @@ test('_applyHooks should pass', function() {
 	);
 });
 
-test('_createTaskSequence should create sequences that work with async methods', function(done) {
+test('_createTaskSequence should create sequences that work with async methods', (done) => {
 	var sequence = prototype._createTaskSequence(_.noop, {});
 
 	expect(sequence.length).toBe(1);
@@ -109,14 +110,14 @@ test('_createTaskSequence should create sequences that work with async methods',
 	expect(_.isFunction(sequence[0])).toBe(true);
 	expect(_.isFunction(sequence[1])).toBe(true);
 
-	async.series(sequence, function() {
+	async.series(sequence, () => {
 		expect(hookSpy.calledOnce).toBe(true);
 
 		done();
 	});
 });
 
-test('_getTaskHookMap should create valid taskHookMap', function() {
+test('_getTaskHookMap should create valid taskHookMap', () => {
 	prototype.hooks = {
 		'after:build': _.noop,
 		'before:deploy': _.noop,
@@ -135,7 +136,7 @@ test('_getTaskHookMap should create valid taskHookMap', function() {
 	});
 });
 
-test('_getTaskName should split hook name into correct sections', function() {
+test('_getTaskName should split hook name into correct sections', () => {
 	var array = prototype._getTaskName('after:build');
 
 	expect(array[0]).toBe('after');
@@ -152,7 +153,7 @@ test('_getTaskName should split hook name into correct sections', function() {
 	expect(array[1]).toBe('build:base');
 });
 
-test('_logHookRegister should log message only if fn is a function', function() {
+test('_logHookRegister should log message only if fn is a function', () => {
 	gutil.log = sinon.spy();
 
 	prototype._logHookRegister('test', _.noop);
@@ -161,7 +162,7 @@ test('_logHookRegister should log message only if fn is a function', function() 
 	expect(gutil.log.callCount).toBe(1);
 });
 
-test('_registerHookFn should register hookFn if it is a function and log message if defined as anything else', function() {
+test('_registerHookFn should register hookFn if it is a function and log message if defined as anything else', () => {
 	gutil.log = sinon.spy();
 
 	prototype._registerHookFn();
@@ -184,7 +185,7 @@ test('_registerHookFn should register hookFn if it is a function and log message
 	expect(prototype.hookFn.calledWithExactly('gulp', 'options')).toBe(true);
 });
 
-test('_registerHookModule should register hook or log appropriate log messages', function() {
+test('_registerHookModule should register hook or log appropriate log messages', () => {
 	gutil.log = sinon.spy();
 
 	prototype._registerHookModule('non-existent-module');
@@ -221,7 +222,7 @@ test('_registerHookModule should register hook or log appropriate log messages',
 	expect(gutil.log.callCount).toBe(1);
 });
 
-test('_registerHookModule should pass correct arguments to hook modules', function() {
+test('_registerHookModule should pass correct arguments to hook modules', () => {
 	var hookModulePath = path.join(
 		__dirname,
 		'../fixtures/hook_modules/hook-module-4'
@@ -238,7 +239,7 @@ test('_registerHookModule should pass correct arguments to hook modules', functi
 	expect(moduleHook.callCount).toBe(1);
 });
 
-test('_registerHookModules should accept single or multiple hook modules and register them', function() {
+test('_registerHookModules should accept single or multiple hook modules and register them', () => {
 	var hookModule1Path = path.join(
 		__dirname,
 		'../fixtures/hook_modules/hook-module-1'
@@ -279,7 +280,7 @@ test('_registerHookModules should accept single or multiple hook modules and reg
 	expect(prototype._registerHookModule.callCount).toBe(3);
 });
 
-test('_registerHooks should create gulp.hook function that adds hook to hooks object', function() {
+test('_registerHooks should create gulp.hook function that adds hook to hooks object', () => {
 	prototype.gulp = {};
 	prototype._registerHooks();
 

--- a/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
@@ -25,12 +25,12 @@ beforeEach(() => {
 	prototype = _.create(RegisterHooks.prototype);
 });
 
-test('_addToSequence should add function to sequence differently based on if cb is expected or stream is returned', (done) => {
+test('_addToSequence should add function to sequence differently based on if cb is expected or stream is returned', done => {
 	var sequence = [];
 
 	var spy = sinon.spy();
 
-	prototype._addToSequence(sequence, (cb) => {
+	prototype._addToSequence(sequence, cb => {
 		spy();
 
 		cb();
@@ -62,11 +62,11 @@ test('_addToSequence should add function to sequence differently based on if cb 
 test('_applyHooks should pass', () => {
 	prototype.gulp = new Gulp();
 
-	prototype.gulp.task('test', ['test2'], (cb) => {
+	prototype.gulp.task('test', ['test2'], cb => {
 		cb();
 	});
 
-	prototype.gulp.task('test2', (cb) => {
+	prototype.gulp.task('test2', cb => {
 		cb();
 	});
 
@@ -88,7 +88,7 @@ test('_applyHooks should pass', () => {
 	);
 });
 
-test('_createTaskSequence should create sequences that work with async methods', (done) => {
+test('_createTaskSequence should create sequences that work with async methods', done => {
 	var sequence = prototype._createTaskSequence(_.noop, {});
 
 	expect(sequence.length).toBe(1);

--- a/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
@@ -195,6 +195,7 @@ test('_registerHookModule should register hook or log appropriate log messages',
 	);
 	expect(gutil.log.callCount).toBe(1);
 
+	// eslint-disable-next-line liferay/no-dynamic-require
 	require(path.join(__dirname, '../fixtures/hook_modules/hook-module-1'));
 
 	prototype.gulp = {
@@ -228,6 +229,7 @@ test('_registerHookModule should pass correct arguments to hook modules', () => 
 		'../fixtures/hook_modules/hook-module-4'
 	);
 
+	// eslint-disable-next-line liferay/no-dynamic-require
 	var moduleHook = require(hookModulePath)().reset();
 
 	prototype.gulp = 'gulp';

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -10,6 +10,7 @@ var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var Gulp = require('gulp').Gulp;
+
 var os = require('os');
 var path = require('path');
 
@@ -32,11 +33,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll(function(done) {
+beforeAll((done) => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		function(err) {
+		(err) => {
 			if (err) {
 				throw err;
 			}
@@ -62,24 +63,24 @@ beforeAll(function(done) {
 	);
 });
 
-afterAll(function(done) {
+afterAll((done) => {
 	del([path.join(tempPath, '**')], {
 		force: true,
-	}).then(function() {
+	}).then(() => {
 		process.chdir(initCwd);
 
 		done();
 	});
 });
 
-afterEach(function() {
+afterEach(() => {
 	del.sync(path.join(deployPath, '**'), {
 		force: true,
 	});
 });
 
-test('deploy task should deploy war file to specified appserver', function(done) {
-	runSequence('deploy', function() {
+test('deploy task should deploy war file to specified appserver', (done) => {
+	runSequence('deploy', () => {
 		assert.isFile(path.join(deployPath, 'test-plugin-layouttpl.war'));
 
 		expect(gulp.storage.get('deployed')).toBe(true);

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -33,11 +33,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll((done) => {
+beforeAll(done => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		(err) => {
+		err => {
 			if (err) {
 				throw err;
 			}
@@ -63,7 +63,7 @@ beforeAll((done) => {
 	);
 });
 
-afterAll((done) => {
+afterAll(done => {
 	del([path.join(tempPath, '**')], {
 		force: true,
 	}).then(() => {
@@ -79,7 +79,7 @@ afterEach(() => {
 	});
 });
 
-test('deploy task should deploy war file to specified appserver', (done) => {
+test('deploy task should deploy war file to specified appserver', done => {
 	runSequence('deploy', () => {
 		assert.isFile(path.join(deployPath, 'test-plugin-layouttpl.war'));
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/init.js
@@ -6,10 +6,11 @@
 
 'use strict';
 
-var _ = require('lodash');
 var del = require('del');
 var fs = require('fs-extra');
+var _ = require('lodash');
 var Gulp = require('gulp').Gulp;
+
 var os = require('os');
 var path = require('path');
 var sinon = require('sinon');
@@ -27,11 +28,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll(function(done) {
+beforeAll((done) => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		function(err) {
+		(err) => {
 			if (err) {
 				throw err;
 			}
@@ -51,17 +52,17 @@ beforeAll(function(done) {
 	);
 });
 
-afterAll(function(done) {
+afterAll((done) => {
 	del([path.join(tempPath, '**')], {
 		force: true,
-	}).then(function() {
+	}).then(() => {
 		process.chdir(initCwd);
 
 		done();
 	});
 });
 
-test('plugin:init should prompt user for appserver information', function() {
+test('plugin:init should prompt user for appserver information', () => {
 	var InitPrompt = require('../../lib/init_prompt');
 
 	var _prompt = InitPrompt.prototype._prompt;

--- a/packages/liferay-theme-tasks/plugin/test/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/init.js
@@ -28,11 +28,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll((done) => {
+beforeAll(done => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		(err) => {
+		err => {
 			if (err) {
 				throw err;
 			}
@@ -52,7 +52,7 @@ beforeAll((done) => {
 	);
 });
 
-afterAll((done) => {
+afterAll(done => {
 	del([path.join(tempPath, '**')], {
 		force: true,
 	}).then(() => {

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -31,11 +31,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll((done) => {
+beforeAll(done => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		(err) => {
+		err => {
 			if (err) {
 				throw err;
 			}
@@ -55,7 +55,7 @@ beforeAll((done) => {
 	);
 });
 
-afterAll((done) => {
+afterAll(done => {
 	del([path.join(tempPath, '**')], {
 		force: true,
 	}).then(() => {
@@ -65,7 +65,7 @@ afterAll((done) => {
 	});
 });
 
-test('plugin:version should add package.json version to liferay-plugin-package.properties', (done) => {
+test('plugin:version should add package.json version to liferay-plugin-package.properties', done => {
 	runSequence('plugin:version', () => {
 		assert.fileContentMatch(
 			path.join(
@@ -79,7 +79,7 @@ test('plugin:version should add package.json version to liferay-plugin-package.p
 	});
 });
 
-test('plugin:version should add package.json version to liferay-plugin-package.properties', (done) => {
+test('plugin:version should add package.json version to liferay-plugin-package.properties', done => {
 	var pkgPath = path.join(tempPath, 'package.json');
 
 	var pkg = require(pkgPath);

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -82,6 +82,7 @@ test('plugin:version should add package.json version to liferay-plugin-package.p
 test('plugin:version should add package.json version to liferay-plugin-package.properties', done => {
 	var pkgPath = path.join(tempPath, 'package.json');
 
+	// eslint-disable-next-line liferay/no-dynamic-require
 	var pkg = require(pkgPath);
 
 	pkg.version = '1.2.4';

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -10,6 +10,7 @@ var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var Gulp = require('gulp').Gulp;
+
 var os = require('os');
 var path = require('path');
 
@@ -30,11 +31,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll(function(done) {
+beforeAll((done) => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		function(err) {
+		(err) => {
 			if (err) {
 				throw err;
 			}
@@ -54,18 +55,18 @@ beforeAll(function(done) {
 	);
 });
 
-afterAll(function(done) {
+afterAll((done) => {
 	del([path.join(tempPath, '**')], {
 		force: true,
-	}).then(function() {
+	}).then(() => {
 		process.chdir(initCwd);
 
 		done();
 	});
 });
 
-test('plugin:version should add package.json version to liferay-plugin-package.properties', function(done) {
-	runSequence('plugin:version', function() {
+test('plugin:version should add package.json version to liferay-plugin-package.properties', (done) => {
+	runSequence('plugin:version', () => {
 		assert.fileContentMatch(
 			path.join(
 				tempPath,
@@ -78,7 +79,7 @@ test('plugin:version should add package.json version to liferay-plugin-package.p
 	});
 });
 
-test('plugin:version should add package.json version to liferay-plugin-package.properties', function(done) {
+test('plugin:version should add package.json version to liferay-plugin-package.properties', (done) => {
 	var pkgPath = path.join(tempPath, 'package.json');
 
 	var pkg = require(pkgPath);
@@ -87,7 +88,7 @@ test('plugin:version should add package.json version to liferay-plugin-package.p
 
 	fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, '\t'));
 
-	runSequence('plugin:version', function() {
+	runSequence('plugin:version', () => {
 		assert.fileContentMatch(
 			path.join(
 				tempPath,

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -10,6 +10,7 @@ var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var Gulp = require('gulp').Gulp;
+
 var os = require('os');
 var path = require('path');
 
@@ -30,11 +31,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll(function(done) {
+beforeAll((done) => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		function(err) {
+		(err) => {
 			if (err) {
 				throw err;
 			}
@@ -54,25 +55,25 @@ beforeAll(function(done) {
 	);
 });
 
-afterAll(function(done) {
+afterAll((done) => {
 	del([path.join(tempPath, '**')], {
 		force: true,
-	}).then(function() {
+	}).then(() => {
 		process.chdir(initCwd);
 
 		done();
 	});
 });
 
-test('plugin:war should build war file', function(done) {
-	runSequence('plugin:war', function() {
+test('plugin:war should build war file', (done) => {
+	runSequence('plugin:war', () => {
 		assert.isFile(path.join(tempPath, 'dist', 'test-plugin-layouttpl.war'));
 
 		done();
 	});
 });
 
-test('plugin:war should use name for war file and pathDist for alternative dist location', function(done) {
+test('plugin:war should use name for war file and pathDist for alternative dist location', (done) => {
 	gulp = new Gulp();
 
 	registerTasks({
@@ -83,7 +84,7 @@ test('plugin:war should use name for war file and pathDist for alternative dist 
 
 	runSequence = require('run-sequence').use(gulp);
 
-	runSequence('plugin:war', function() {
+	runSequence('plugin:war', () => {
 		assert.isFile(
 			path.join(tempPath, 'dist_alternative', 'my-plugin-name.war')
 		);

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -31,11 +31,11 @@ var initCwd = process.cwd();
 var registerTasks;
 var runSequence;
 
-beforeAll((done) => {
+beforeAll(done => {
 	fs.copy(
 		path.join(__dirname, '../fixtures/plugins/test-plugin-layouttpl'),
 		tempPath,
-		(err) => {
+		err => {
 			if (err) {
 				throw err;
 			}
@@ -55,7 +55,7 @@ beforeAll((done) => {
 	);
 });
 
-afterAll((done) => {
+afterAll(done => {
 	del([path.join(tempPath, '**')], {
 		force: true,
 	}).then(() => {
@@ -65,7 +65,7 @@ afterAll((done) => {
 	});
 });
 
-test('plugin:war should build war file', (done) => {
+test('plugin:war should build war file', done => {
 	runSequence('plugin:war', () => {
 		assert.isFile(path.join(tempPath, 'dist', 'test-plugin-layouttpl.war'));
 
@@ -73,7 +73,7 @@ test('plugin:war should build war file', (done) => {
 	});
 });
 
-test('plugin:war should use name for war file and pathDist for alternative dist location', (done) => {
+test('plugin:war should use name for war file and pathDist for alternative dist location', done => {
 	gulp = new Gulp();
 
 	registerTasks({

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -57,6 +57,7 @@ describe('using lib_sass', () => {
 		const config = testUtil.copyTempTheme({
 			namespace,
 			registerTasksOptions: {
+				hookFn: buildHookFn,
 				sassOptions: defaults => {
 					sassOptionsSpy();
 
@@ -64,7 +65,6 @@ describe('using lib_sass', () => {
 
 					return defaults;
 				},
-				hookFn: buildHookFn,
 			},
 			themeConfig: {},
 			themeName,

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs-extra');
 const parseString = require('xml2js').parseString;
+
 const path = require('path');
 const sinon = require('sinon');
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
@@ -62,7 +62,7 @@ afterEach(() => {
 	});
 });
 
-it('should deploy to deploy server', done => {
+it('deploys to deploy server', done => {
 	runSequence('deploy', err => {
 		if (err) throw err;
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -46,7 +46,7 @@ describe('globally installed theme', () => {
 			'init'
 		);
 
-		runSequence('kickstart', function() {
+		runSequence('kickstart', () => {
 			const srcDir = path.join(tempPath, 'src');
 
 			expect(

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -40,7 +40,7 @@ describe('globally installed theme', () => {
 		KickstartPrompt = require('../../lib/prompts/kickstart_prompt');
 	});
 
-	it('should kickstart', done => {
+	it('kickstarts', done => {
 		const promptInitSpy = prototypeMethodSpy.add(
 			KickstartPrompt.prototype,
 			'init'
@@ -112,7 +112,7 @@ describe('npm theme', () => {
 		KickstartPrompt = require('../../lib/prompts/kickstart_prompt');
 	});
 
-	it('should kickstart', done => {
+	it('kickstarts', done => {
 		const promptInitSpy = prototypeMethodSpy.add(
 			KickstartPrompt.prototype,
 			'init'

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -29,9 +29,9 @@ describe('globally installed theme', () => {
 	beforeEach(() => {
 		const config = testUtil.copyTempTheme({
 			namespace: 'kickstart_task_global',
+			registerTasks: true,
 			themeName: 'base-theme',
 			version: '7.1',
-			registerTasks: true,
 		});
 
 		runSequence = config.runSequence;

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -8,12 +8,13 @@
 
 const del = require('del');
 const fs = require('fs-extra');
-const _ = require('lodash');
-const path = require('path');
-const plugins = require('gulp-load-plugins')();
 const replace = require('gulp-replace-task');
-const through = require('through2');
+const _ = require('lodash');
+const plugins = require('gulp-load-plugins')();
+
+const path = require('path');
 const PluginError = require('plugin-error');
+const through = require('through2');
 
 const getBaseThemeDependencies = require('../lib/getBaseThemeDependencies');
 const lfrThemeConfig = require('../lib/liferay_theme_config');
@@ -37,7 +38,7 @@ function injectJS() {
 		if (!file.path.match(targetRegExp) || file.isNull()) {
 			// Nothing to do.
 		} else if (file.isStream()) {
-			file.contents = file.contents.pipe(function() {
+			file.contents = file.contents.pipe(() => {
 				let output = '';
 				return through(
 					function transform(chunk, encoding, callback) {
@@ -70,7 +71,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build', function(cb) {
+	gulp.task('build', (cb) => {
 		runSequence(
 			'build:clean',
 			'build:base',
@@ -92,11 +93,11 @@ module.exports = function(options) {
 		);
 	});
 
-	gulp.task('build:clean', function(cb) {
+	gulp.task('build:clean', (cb) => {
 		del([pathBuild]).then(() => cb());
 	});
 
-	gulp.task('build:base', function() {
+	gulp.task('build:base', () => {
 		const sourceFiles = getBaseThemeDependencies();
 
 		return gulp
@@ -105,7 +106,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild));
 	});
 
-	gulp.task('build:src', function() {
+	gulp.task('build:src', () => {
 		return gulp
 			.src(path.join(pathSrc, '**/*'), {
 				base: pathSrc,
@@ -113,7 +114,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild));
 	});
 
-	gulp.task('build:web-inf', function() {
+	gulp.task('build:web-inf', () => {
 		return gulp
 			.src(pathBuild + '/WEB-INF/src/**/*', {
 				base: pathBuild + '/WEB-INF/src',
@@ -121,12 +122,12 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild + '/WEB-INF/classes'));
 	});
 
-	gulp.task('build:liferay-look-and-feel', function(cb) {
+	gulp.task('build:liferay-look-and-feel', (cb) => {
 		const themePath = process.cwd();
 
-		lookAndFeelUtil.mergeLookAndFeelJSON(themePath, {}, function(
+		lookAndFeelUtil.mergeLookAndFeelJSON(themePath, {}, (
 			lookAndFeelJSON
-		) {
+		) => {
 			if (!lookAndFeelJSON) {
 				return cb();
 			}
@@ -159,7 +160,7 @@ module.exports = function(options) {
 					'WEB-INF/liferay-look-and-feel.xml'
 				),
 				xml,
-				function(err) {
+				(err) => {
 					if (err) {
 						throw err;
 					}
@@ -170,7 +171,7 @@ module.exports = function(options) {
 		});
 	});
 
-	gulp.task('build:hook', function() {
+	gulp.task('build:hook', () => {
 		const languageProperties = themeUtil.getLanguageProperties(pathSrc);
 
 		return gulp
@@ -197,12 +198,12 @@ module.exports = function(options) {
 			.pipe(gulp.dest(path.join(pathBuild, 'WEB-INF')));
 	});
 
-	gulp.task('build:rename-css-dir', function(cb) {
+	gulp.task('build:rename-css-dir', (cb) => {
 		fs.rename(pathBuild + '/css', pathBuild + '/_css', cb);
 	});
 
 	// Temp fix for libSass compilation issue with empty url() functions
-	gulp.task('build:fix-url-functions', function(cb) {
+	gulp.task('build:fix-url-functions', (cb) => {
 		gulp.src(pathBuild + '/_css/**/*.css')
 			.pipe(
 				replace({
@@ -222,17 +223,17 @@ module.exports = function(options) {
 			.on('end', cb);
 	});
 
-	gulp.task('build:move-compiled-css', function() {
+	gulp.task('build:move-compiled-css', () => {
 		return gulp
 			.src(pathBuild + '/_css/**/*')
 			.pipe(gulp.dest(pathBuild + '/css'));
 	});
 
-	gulp.task('build:remove-old-css-dir', function(cb) {
+	gulp.task('build:remove-old-css-dir', (cb) => {
 		del([pathBuild + '/_css']).then(() => cb());
 	});
 
-	gulp.task('build:fix-at-directives', function() {
+	gulp.task('build:fix-at-directives', () => {
 		return gulp
 			.src(pathBuild + '/css/*.css')
 			.pipe(
@@ -243,7 +244,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild + '/css'));
 	});
 
-	gulp.task('build:r2', function() {
+	gulp.task('build:r2', () => {
 		const r2 = require('gulp-liferay-r2-css');
 
 		return gulp
@@ -286,7 +287,7 @@ module.exports = function(options) {
 function getFixAtDirectivesPatterns() {
 	const keyframeRulesReplace = function(match, m1, m2) {
 		return (
-			_.map(m1.split(','), function(item) {
+			_.map(m1.split(','), (item) => {
 				return item.replace(/.*?(from|to|[0-9.]+%)/g, '$1');
 			}).join(',') + m2
 		);

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -71,7 +71,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build', (cb) => {
+	gulp.task('build', cb => {
 		runSequence(
 			'build:clean',
 			'build:base',
@@ -93,7 +93,7 @@ module.exports = function(options) {
 		);
 	});
 
-	gulp.task('build:clean', (cb) => {
+	gulp.task('build:clean', cb => {
 		del([pathBuild]).then(() => cb());
 	});
 
@@ -122,12 +122,10 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild + '/WEB-INF/classes'));
 	});
 
-	gulp.task('build:liferay-look-and-feel', (cb) => {
+	gulp.task('build:liferay-look-and-feel', cb => {
 		const themePath = process.cwd();
 
-		lookAndFeelUtil.mergeLookAndFeelJSON(themePath, {}, (
-			lookAndFeelJSON
-		) => {
+		lookAndFeelUtil.mergeLookAndFeelJSON(themePath, {}, lookAndFeelJSON => {
 			if (!lookAndFeelJSON) {
 				return cb();
 			}
@@ -160,7 +158,7 @@ module.exports = function(options) {
 					'WEB-INF/liferay-look-and-feel.xml'
 				),
 				xml,
-				(err) => {
+				err => {
 					if (err) {
 						throw err;
 					}
@@ -198,12 +196,12 @@ module.exports = function(options) {
 			.pipe(gulp.dest(path.join(pathBuild, 'WEB-INF')));
 	});
 
-	gulp.task('build:rename-css-dir', (cb) => {
+	gulp.task('build:rename-css-dir', cb => {
 		fs.rename(pathBuild + '/css', pathBuild + '/_css', cb);
 	});
 
 	// Temp fix for libSass compilation issue with empty url() functions
-	gulp.task('build:fix-url-functions', (cb) => {
+	gulp.task('build:fix-url-functions', cb => {
 		gulp.src(pathBuild + '/_css/**/*.css')
 			.pipe(
 				replace({
@@ -229,7 +227,7 @@ module.exports = function(options) {
 			.pipe(gulp.dest(pathBuild + '/css'));
 	});
 
-	gulp.task('build:remove-old-css-dir', (cb) => {
+	gulp.task('build:remove-old-css-dir', cb => {
 		del([pathBuild + '/_css']).then(() => cb());
 	});
 
@@ -287,7 +285,7 @@ module.exports = function(options) {
 function getFixAtDirectivesPatterns() {
 	const keyframeRulesReplace = function(match, m1, m2) {
 		return (
-			_.map(m1.split(','), (item) => {
+			_.map(m1.split(','), item => {
 				return item.replace(/.*?(from|to|[0-9.]+%)/g, '$1');
 			}).join(',') + m2
 		);

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -257,9 +257,7 @@ module.exports = function(options) {
 	});
 
 	gulp.task('build:copy:fontAwesome', done => {
-		const themePath = process.cwd();
-
-		const packageJSON = require(path.join(themePath, 'package.json'))
+		const packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 			.liferayTheme;
 
 		if (!packageJSON.fontAwesome) {

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -7,11 +7,11 @@
 'use strict';
 
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 const fs = require('fs');
+const postcss = require('gulp-postcss');
 const _ = require('lodash');
 const path = require('path');
-const log = require('fancy-log');
-const postcss = require('gulp-postcss');
 
 const {createBourbonFile} = require('../../lib/bourbon_dependencies');
 const lfrThemeConfig = require('../../lib/liferay_theme_config');
@@ -31,13 +31,13 @@ module.exports = function(options) {
 	};
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build:compile-css', function(cb) {
+	gulp.task('build:compile-css', (cb) => {
 		// For backwards compatibility we keep this task around, but all it does
 		// is call through to the one that does the actual work:
 		runSequence('build:compile-lib-sass', cb);
 	});
 
-	gulp.task('build:compile-lib-sass', function(cb) {
+	gulp.task('build:compile-lib-sass', (cb) => {
 		const gulpIf = require('gulp-if');
 		const gulpSass = require('gulp-sass');
 		const gulpSourceMaps = require('gulp-sourcemaps');

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -31,13 +31,13 @@ module.exports = function(options) {
 	};
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build:compile-css', (cb) => {
+	gulp.task('build:compile-css', cb => {
 		// For backwards compatibility we keep this task around, but all it does
 		// is call through to the one that does the actual work:
 		runSequence('build:compile-lib-sass', cb);
 	});
 
-	gulp.task('build:compile-lib-sass', (cb) => {
+	gulp.task('build:compile-lib-sass', cb => {
 		const gulpIf = require('gulp-if');
 		const gulpSass = require('gulp-sass');
 		const gulpSourceMaps = require('gulp-sourcemaps');

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -91,7 +91,8 @@ function exists(file) {
 function getPostCSSRC() {
 	const themeConfig = lfrThemeConfig.getConfig(true);
 	return (
-		(themeConfig.hasOwnProperty('postcss') && 'package.json "postcss"') ||
+		(Object.prototype.hasOwnProperty.call(themeConfig, 'postcss') &&
+			'package.json "postcss"') ||
 		exists('.postcssrc') ||
 		exists('.postcssrc.js') ||
 		exists('.postcssrc.json') ||

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -120,6 +120,7 @@ function getPostCSSOptions(config) {
 		postCSSOptions.enabled = true;
 
 		postCSSOptions.plugins = config.map(pluginDependency =>
+			// eslint-disable-next-line liferay/no-dynamic-require
 			require(pluginDependency)
 		);
 	} else if (rc) {

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -6,12 +6,13 @@
 
 'use strict';
 
-const _ = require('lodash');
-const async = require('async');
 const colors = require('ansi-colors');
+const async = require('async');
 const log = require('fancy-log');
+const _ = require('lodash');
 const path = require('path');
 const plugins = require('gulp-load-plugins')();
+
 const vinylPaths = require('vinyl-paths');
 
 const lfrThemeConfig = require('../../lib/liferay_theme_config');
@@ -30,7 +31,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build:themelets', function(cb) {
+	gulp.task('build:themelets', (cb) => {
 		runSequence(
 			['build:themelet-src'],
 			['build:themelet-css-inject', 'build:themelet-js-inject'],
@@ -38,7 +39,7 @@ module.exports = function(options) {
 		);
 	});
 
-	gulp.task('build:themelet-css-inject', function(cb) {
+	gulp.task('build:themelet-css-inject', (cb) => {
 		const themeSrcPaths = path.join(
 			pathBuild,
 			'themelets',
@@ -55,7 +56,7 @@ module.exports = function(options) {
 				read: false,
 			})
 			.pipe(
-				vinylPaths(function(path, cb) {
+				vinylPaths((path, cb) => {
 					themeletSources = true;
 
 					cb();
@@ -86,7 +87,7 @@ module.exports = function(options) {
 				})
 			)
 			.pipe(gulp.dest(path.join(pathBuild, 'css')))
-			.on('end', function() {
+			.on('end', () => {
 				if (
 					!injected &&
 					themeletSources &&
@@ -103,7 +104,7 @@ module.exports = function(options) {
 			});
 	});
 
-	gulp.task('build:themelet-js-inject', function(cb) {
+	gulp.task('build:themelet-js-inject', (cb) => {
 		const themeSrcPaths = path.join(
 			pathBuild,
 			'themelets',
@@ -120,7 +121,7 @@ module.exports = function(options) {
 				read: false,
 			})
 			.pipe(
-				vinylPaths(function(path, cb) {
+				vinylPaths((path, cb) => {
 					themeletSources = true;
 
 					cb();
@@ -163,7 +164,7 @@ module.exports = function(options) {
 				})
 			)
 			.pipe(gulp.dest(path.join(pathBuild, 'templates')))
-			.on('end', function() {
+			.on('end', () => {
 				if (
 					!injected &&
 					themeletSources &&
@@ -180,8 +181,8 @@ module.exports = function(options) {
 			});
 	});
 
-	gulp.task('build:themelet-src', function(cb) {
-		runThemeletDependenciesSeries(function(item, index, done) {
+	gulp.task('build:themelet-src', (cb) => {
+		runThemeletDependenciesSeries((item, index, done) => {
 			gulp.src(path.resolve(CWD, 'node_modules', index, 'src', '**', '*'))
 				.pipe(gulp.dest(path.join(pathBuild, 'themelets', index)))
 				.on('end', done);

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
 
 	const runSequence = require('run-sequence').use(gulp);
 
-	gulp.task('build:themelets', (cb) => {
+	gulp.task('build:themelets', cb => {
 		runSequence(
 			['build:themelet-src'],
 			['build:themelet-css-inject', 'build:themelet-js-inject'],
@@ -39,7 +39,7 @@ module.exports = function(options) {
 		);
 	});
 
-	gulp.task('build:themelet-css-inject', (cb) => {
+	gulp.task('build:themelet-css-inject', cb => {
 		const themeSrcPaths = path.join(
 			pathBuild,
 			'themelets',
@@ -104,7 +104,7 @@ module.exports = function(options) {
 			});
 	});
 
-	gulp.task('build:themelet-js-inject', (cb) => {
+	gulp.task('build:themelet-js-inject', cb => {
 		const themeSrcPaths = path.join(
 			pathBuild,
 			'themelets',
@@ -181,7 +181,7 @@ module.exports = function(options) {
 			});
 	});
 
-	gulp.task('build:themelet-src', (cb) => {
+	gulp.task('build:themelet-src', cb => {
 		runThemeletDependenciesSeries((item, index, done) => {
 			gulp.src(path.resolve(CWD, 'node_modules', index, 'src', '**', '*'))
 				.pipe(gulp.dest(path.join(pathBuild, 'themelets', index)))

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -9,6 +9,7 @@
 const colors = require('ansi-colors');
 const async = require('async');
 const log = require('fancy-log');
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const plugins = require('gulp-load-plugins')();
@@ -213,7 +214,7 @@ function getThemeletFilePathArray(filePath) {
 }
 
 function getThemeletDependencies() {
-	const packageJSON = require(path.join(CWD, 'package.json'));
+	const packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 	let themeletDependencies;
 

--- a/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/tasks/deploy.js
@@ -33,7 +33,7 @@ function registerTasks(options) {
 		runSequence.apply(this, sequence);
 	});
 
-	gulp.task('deploy:docker', function(cb) {
+	gulp.task('deploy:docker', (cb) => {
 		const deployPath = storage.get('deployPath');
 		const themeName = themeConfig.name;
 
@@ -42,7 +42,7 @@ function registerTasks(options) {
 			pathDist,
 			deployPath,
 			[themeName + '.war'],
-			function(err, _data) {
+			(err, _data) => {
 				if (err) throw err;
 
 				storage.set('deployed', true);
@@ -64,7 +64,7 @@ function registerTasks(options) {
 		runSequence.apply(this, sequence);
 	});
 
-	gulp.task('deploy-live:war', function(cb) {
+	gulp.task('deploy-live:war', (cb) => {
 		const password = argv.p || argv.password;
 		const url = argv.url || storage.get('url');
 		const username = argv.u || argv.username;

--- a/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/tasks/deploy.js
@@ -33,7 +33,7 @@ function registerTasks(options) {
 		runSequence.apply(this, sequence);
 	});
 
-	gulp.task('deploy:docker', (cb) => {
+	gulp.task('deploy:docker', cb => {
 		const deployPath = storage.get('deployPath');
 		const themeName = themeConfig.name;
 
@@ -64,7 +64,7 @@ function registerTasks(options) {
 		runSequence.apply(this, sequence);
 	});
 
-	gulp.task('deploy-live:war', (cb) => {
+	gulp.task('deploy-live:war', cb => {
 		const password = argv.p || argv.password;
 		const url = argv.url || storage.get('url');
 		const username = argv.u || argv.username;

--- a/packages/liferay-theme-tasks/tasks/extend.js
+++ b/packages/liferay-theme-tasks/tasks/extend.js
@@ -12,7 +12,7 @@ const ExtendPrompt = require('../lib/prompts/extend_prompt');
 module.exports = function(options) {
 	const gulp = options.gulp;
 
-	gulp.task('extend', (cb) => {
+	gulp.task('extend', cb => {
 		ExtendPrompt.prompt(
 			{
 				themeConfig: lfrThemeConfig.getConfig(),

--- a/packages/liferay-theme-tasks/tasks/extend.js
+++ b/packages/liferay-theme-tasks/tasks/extend.js
@@ -6,13 +6,13 @@
 
 'use strict';
 
-const ExtendPrompt = require('../lib/prompts/extend_prompt');
 const lfrThemeConfig = require('../lib/liferay_theme_config');
+const ExtendPrompt = require('../lib/prompts/extend_prompt');
 
 module.exports = function(options) {
 	const gulp = options.gulp;
 
-	gulp.task('extend', function(cb) {
+	gulp.task('extend', (cb) => {
 		ExtendPrompt.prompt(
 			{
 				themeConfig: lfrThemeConfig.getConfig(),

--- a/packages/liferay-theme-tasks/tasks/kickstart.js
+++ b/packages/liferay-theme-tasks/tasks/kickstart.js
@@ -6,20 +6,20 @@
 
 'use strict';
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
 const del = require('del');
 const log = require('fancy-log');
+const _ = require('lodash');
 const path = require('path');
 
-const KickstartPrompt = require('../lib/prompts/kickstart_prompt');
 const lfrThemeConfig = require('../lib/liferay_theme_config');
+const KickstartPrompt = require('../lib/prompts/kickstart_prompt');
 
 function registerTasks(options) {
 	const gulp = options.gulp;
 	const pathSrc = options.pathSrc;
 
-	gulp.task('kickstart', function(cb) {
+	gulp.task('kickstart', (cb) => {
 		log(
 			colors.yellow('Warning:'),
 			'the',
@@ -31,7 +31,7 @@ function registerTasks(options) {
 			{
 				themeConfig: lfrThemeConfig.getConfig(),
 			},
-			function(answers) {
+			(answers) => {
 				let tempNodeModulesPath;
 				let themeSrcPath;
 
@@ -54,7 +54,7 @@ function registerTasks(options) {
 				if (themeSrcPath) {
 					const globs = _.map(
 						['css', 'images', 'js', 'templates'],
-						function(folder) {
+						(folder) => {
 							return path.join(themeSrcPath, folder, '**/*');
 						}
 					);
@@ -63,7 +63,7 @@ function registerTasks(options) {
 						base: themeSrcPath,
 					})
 						.pipe(gulp.dest(pathSrc))
-						.on('end', function() {
+						.on('end', () => {
 							if (tempNodeModulesPath) {
 								del([tempNodeModulesPath]).then(() => cb());
 							} else {

--- a/packages/liferay-theme-tasks/tasks/kickstart.js
+++ b/packages/liferay-theme-tasks/tasks/kickstart.js
@@ -19,7 +19,7 @@ function registerTasks(options) {
 	const gulp = options.gulp;
 	const pathSrc = options.pathSrc;
 
-	gulp.task('kickstart', (cb) => {
+	gulp.task('kickstart', cb => {
 		log(
 			colors.yellow('Warning:'),
 			'the',
@@ -31,7 +31,7 @@ function registerTasks(options) {
 			{
 				themeConfig: lfrThemeConfig.getConfig(),
 			},
-			(answers) => {
+			answers => {
 				let tempNodeModulesPath;
 				let themeSrcPath;
 
@@ -54,7 +54,7 @@ function registerTasks(options) {
 				if (themeSrcPath) {
 					const globs = _.map(
 						['css', 'images', 'js', 'templates'],
-						(folder) => {
+						folder => {
 							return path.join(themeSrcPath, folder, '**/*');
 						}
 					);

--- a/packages/liferay-theme-tasks/tasks/overwrite.js
+++ b/packages/liferay-theme-tasks/tasks/overwrite.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
 	const pathBuild = options.pathBuild;
 	const pathSrc = options.pathSrc;
 
-	gulp.task('overwrite', (cb) => {
+	gulp.task('overwrite', cb => {
 		promptFiles('.', cb);
 	});
 
@@ -120,7 +120,7 @@ module.exports = function(options) {
 				name: 'file',
 				type: 'list',
 			},
-			(answers) => {
+			answers => {
 				if (answers.file.dir) {
 					promptFiles(answers.file.path, cb);
 				} else {

--- a/packages/liferay-theme-tasks/tasks/overwrite.js
+++ b/packages/liferay-theme-tasks/tasks/overwrite.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 const fs = require('fs');
 const inquirer = require('inquirer');
-const log = require('fancy-log');
+const _ = require('lodash');
 const path = require('path');
 
 const CWD = process.cwd();
@@ -21,7 +21,7 @@ module.exports = function(options) {
 	const pathBuild = options.pathBuild;
 	const pathSrc = options.pathSrc;
 
-	gulp.task('overwrite', function(cb) {
+	gulp.task('overwrite', (cb) => {
 		promptFiles('.', cb);
 	});
 
@@ -40,7 +40,7 @@ module.exports = function(options) {
 
 		const choices = _.reduce(
 			buildFiles,
-			function(result, item) {
+			(result, item) => {
 				const filePath = path.join(dirPath, item);
 
 				const dir = isDir(filePath);
@@ -120,7 +120,7 @@ module.exports = function(options) {
 				name: 'file',
 				type: 'list',
 			},
-			function(answers) {
+			(answers) => {
 				if (answers.file.dir) {
 					promptFiles(answers.file.path, cb);
 				} else {

--- a/packages/liferay-theme-tasks/tasks/status.js
+++ b/packages/liferay-theme-tasks/tasks/status.js
@@ -10,7 +10,7 @@ const status = require('../lib/status');
 function getStatus(options) {
 	const gulp = options.gulp;
 
-	gulp.task('status', (cb) => {
+	gulp.task('status', cb => {
 		process.stdout.write(status(lfrThemeConfig.getConfig()));
 
 		cb();

--- a/packages/liferay-theme-tasks/tasks/status.js
+++ b/packages/liferay-theme-tasks/tasks/status.js
@@ -10,7 +10,7 @@ const status = require('../lib/status');
 function getStatus(options) {
 	const gulp = options.gulp;
 
-	gulp.task('status', function(cb) {
+	gulp.task('status', (cb) => {
 		process.stdout.write(status(lfrThemeConfig.getConfig()));
 
 		cb();

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -36,6 +36,7 @@ module.exports = function(options) {
 	let versionUpgradeTask;
 
 	if (fs.existsSync(modulePath)) {
+		// eslint-disable-next-line liferay/no-dynamic-require
 		versionUpgradeTask = require(modulePath)(options);
 	}
 

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 const fs = require('fs-extra');
 const inquirer = require('inquirer');
-const log = require('fancy-log');
+const _ = require('lodash');
 const path = require('path');
 const PluginError = require('plugin-error');
 
@@ -39,7 +39,7 @@ module.exports = function(options) {
 		versionUpgradeTask = require(modulePath)(options);
 	}
 
-	gulp.task('upgrade', function(cb) {
+	gulp.task('upgrade', (cb) => {
 		if (_.isFunction(versionUpgradeTask)) {
 			inquirer.prompt(
 				[
@@ -59,11 +59,11 @@ module.exports = function(options) {
 						type: 'confirm',
 					},
 				],
-				function(answers) {
+				(answers) => {
 					if (answers.sure) {
 						options.includeFontAwesome = answers.includeFontAwesome;
 
-						versionUpgradeTask(function(err) {
+						versionUpgradeTask((err) => {
 							if (err) {
 								log(
 									colors.red('Error:'),

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
 		versionUpgradeTask = require(modulePath)(options);
 	}
 
-	gulp.task('upgrade', (cb) => {
+	gulp.task('upgrade', cb => {
 		if (_.isFunction(versionUpgradeTask)) {
 			inquirer.prompt(
 				[
@@ -59,11 +59,11 @@ module.exports = function(options) {
 						type: 'confirm',
 					},
 				],
-				(answers) => {
+				answers => {
 					if (answers.sure) {
 						options.includeFontAwesome = answers.includeFontAwesome;
 
-						versionUpgradeTask((err) => {
+						versionUpgradeTask(err => {
 							if (err) {
 								log(
 									colors.red('Error:'),

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -115,14 +115,14 @@ module.exports = function(options) {
 	/**
 	 * Clean the exploded build dir
 	 */
-	gulp.task('watch:clean', (cb) => {
+	gulp.task('watch:clean', cb => {
 		del([explodedBuildDir]).then(() => cb());
 	});
 
 	/**
 	 * Clean the remote exploded build dir in docker
 	 */
-	gulp.task('watch:docker:clean', (cb) => {
+	gulp.task('watch:docker:clean', cb => {
 		themeUtil.dockerExec(
 			dockerContainerName,
 			'rm -rf ' + dockerBundleDirPath
@@ -134,7 +134,7 @@ module.exports = function(options) {
 	/**
 	 * Copy the exploded build dir to docker
 	 */
-	gulp.task('watch:docker:copy', (cb) => {
+	gulp.task('watch:docker:copy', cb => {
 		themeUtil.dockerExec(
 			dockerContainerName,
 			'mkdir -p ' + dockerBundleDirPath
@@ -172,7 +172,7 @@ module.exports = function(options) {
 
 	let livereload;
 
-	gulp.task('watch:reload', (cb) => {
+	gulp.task('watch:reload', cb => {
 		const changedFile = storage.get('changedFile');
 		const srcPath = path.relative(process.cwd(), changedFile.path);
 		const dstPath = srcPath.replace(/^src\//, '');

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -9,16 +9,17 @@
 const chalk = require('chalk');
 const del = require('del');
 const fs = require('fs');
-const http = require('http');
-const httpProxy = require('http-proxy');
 const passes = require('http-proxy/lib/http-proxy/passes/web-outgoing');
+const httpProxy = require('http-proxy');
+const http = require('http');
 const opn = require('opn');
 const path = require('path');
-const themeUtil = require('../lib/util');
-const tinylr = require('tiny-lr');
 const portfinder = require('portfinder');
+const tinylr = require('tiny-lr');
 const url = require('url');
 const util = require('util');
+
+const themeUtil = require('../lib/util');
 
 const PASSES = Object.values(passes);
 
@@ -114,14 +115,14 @@ module.exports = function(options) {
 	/**
 	 * Clean the exploded build dir
 	 */
-	gulp.task('watch:clean', function(cb) {
+	gulp.task('watch:clean', (cb) => {
 		del([explodedBuildDir]).then(() => cb());
 	});
 
 	/**
 	 * Clean the remote exploded build dir in docker
 	 */
-	gulp.task('watch:docker:clean', function(cb) {
+	gulp.task('watch:docker:clean', (cb) => {
 		themeUtil.dockerExec(
 			dockerContainerName,
 			'rm -rf ' + dockerBundleDirPath
@@ -133,7 +134,7 @@ module.exports = function(options) {
 	/**
 	 * Copy the exploded build dir to docker
 	 */
-	gulp.task('watch:docker:copy', function(cb) {
+	gulp.task('watch:docker:copy', (cb) => {
 		themeUtil.dockerExec(
 			dockerContainerName,
 			'mkdir -p ' + dockerBundleDirPath
@@ -150,7 +151,7 @@ module.exports = function(options) {
 	/**
 	 * Copy output files to exploded build dir
 	 */
-	gulp.task('watch:setup', function() {
+	gulp.task('watch:setup', () => {
 		return gulp
 			.src(path.join(pathBuild, '**/*'))
 			.pipe(gulp.dest(explodedBuildDir));
@@ -171,7 +172,7 @@ module.exports = function(options) {
 
 	let livereload;
 
-	gulp.task('watch:reload', function(cb) {
+	gulp.task('watch:reload', (cb) => {
 		const changedFile = storage.get('changedFile');
 		const srcPath = path.relative(process.cwd(), changedFile.path);
 		const dstPath = srcPath.replace(/^src\//, '');
@@ -208,7 +209,7 @@ module.exports = function(options) {
 
 		const proxy = httpProxy.createServer();
 
-		proxy.on('proxyReq', function(proxyReq, _req, _res, _options) {
+		proxy.on('proxyReq', (proxyReq, _req, _res, _options) => {
 			// Disable compression because it complicates the task of appending
 			// our livereload tag.
 			proxyReq.setHeader('Accept-Encoding', 'identity');
@@ -282,7 +283,7 @@ module.exports = function(options) {
 			} else {
 				dispatchToProxy();
 			}
-		}).listen(httpPort, function() {
+		}).listen(httpPort, () => {
 			const url = `http://localhost:${httpPort}/`;
 			const messages = [
 				`Watch mode is now active at: ${url}`,

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -193,7 +193,7 @@ class PrototypeMethodSpy {
 	}
 
 	flush() {
-		_.forEach(this.methods, (item) => {
+		_.forEach(this.methods, item => {
 			item.parent[item.methodName] = item.method;
 		});
 
@@ -294,7 +294,7 @@ function cleanTempTheme(themeName, version, component, initCwd) {
 function deleteDirJsFromCache(relativePath) {
 	const files = fs.readdirSync(path.join(__dirname, relativePath));
 
-	_.forEach(files, (item) => {
+	_.forEach(files, item => {
 		if (_.endsWith(item, '.js')) {
 			deleteJsFileFromCache(path.join(__dirname, relativePath, item));
 		}

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const _ = require('lodash');
 const del = require('del');
 const fs = require('fs-extra');
+const _ = require('lodash');
 const Gulp = require('gulp').Gulp;
+
 const os = require('os');
 const path = require('path');
 const sinon = require('sinon');
@@ -192,7 +193,7 @@ class PrototypeMethodSpy {
 	}
 
 	flush() {
-		_.forEach(this.methods, function(item) {
+		_.forEach(this.methods, (item) => {
 			item.parent[item.methodName] = item.method;
 		});
 
@@ -293,7 +294,7 @@ function cleanTempTheme(themeName, version, component, initCwd) {
 function deleteDirJsFromCache(relativePath) {
 	const files = fs.readdirSync(path.join(__dirname, relativePath));
 
-	_.forEach(files, function(item) {
+	_.forEach(files, (item) => {
 		if (_.endsWith(item, '.js')) {
 			deleteJsFileFromCache(path.join(__dirname, relativePath, item));
 		}

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -18,54 +18,6 @@ const osTempDir = os.tmpdir();
 /* eslint-disable no-console */
 
 expect.extend({
-	toBeFile(path) {
-		let pass = true;
-		let message = '';
-
-		try {
-			if (!fs.statSync(path).isFile()) {
-				pass = false;
-				message = `Path '${path}' is not a file`;
-			}
-		} catch (err) {
-			pass = false;
-			message = err.toString();
-		}
-
-		if (this.isNot && pass) {
-			message = `File '${path}' exists`;
-		}
-
-		return {
-			message: () => message,
-			pass,
-		};
-	},
-
-	toBeFolder(path) {
-		let pass = true;
-		let message = '';
-
-		try {
-			if (!fs.statSync(path).isDirectory()) {
-				pass = false;
-				message = `Path '${path}' is not a folder`;
-			}
-		} catch (err) {
-			pass = false;
-			message = err.toString();
-		}
-
-		if (this.isNot && pass) {
-			message = `Folder '${path}' exists`;
-		}
-
-		return {
-			message: () => message,
-			pass,
-		};
-	},
-
 	toBeEmptyFolder(path) {
 		let pass = true;
 		let message = '';
@@ -116,6 +68,30 @@ expect.extend({
 		};
 	},
 
+	toBeFile(path) {
+		let pass = true;
+		let message = '';
+
+		try {
+			if (!fs.statSync(path).isFile()) {
+				pass = false;
+				message = `Path '${path}' is not a file`;
+			}
+		} catch (err) {
+			pass = false;
+			message = err.toString();
+		}
+
+		if (this.isNot && pass) {
+			message = `File '${path}' exists`;
+		}
+
+		return {
+			message: () => message,
+			pass,
+		};
+	},
+
 	toBeFileMatching(path, regex) {
 		let pass = true;
 		let message = '';
@@ -158,6 +134,30 @@ expect.extend({
 					message = err.toString();
 				}
 			}
+		}
+
+		return {
+			message: () => message,
+			pass,
+		};
+	},
+
+	toBeFolder(path) {
+		let pass = true;
+		let message = '';
+
+		try {
+			if (!fs.statSync(path).isDirectory()) {
+				pass = false;
+				message = `Path '${path}' is not a folder`;
+			}
+		} catch (err) {
+			pass = false;
+			message = err.toString();
+		}
+
+		if (this.isNot && pass) {
+			message = `Folder '${path}' exists`;
 		}
 
 		return {
@@ -255,9 +255,9 @@ function copyTempTheme(options) {
 		registerTasksOptions = _.assign(
 			{
 				distName: 'base-theme',
-				pathBuild: './custom_build_path',
 				gulp,
 				insideTests: true,
+				pathBuild: './custom_build_path',
 			},
 			options.registerTasksOptions
 		);
@@ -312,10 +312,10 @@ function stripNewlines(string) {
 }
 
 module.exports = {
-	copyTempTheme,
-	cleanTempTheme,
 	PrototypeMethodSpy,
 	assertBoundFunction,
+	cleanTempTheme,
+	copyTempTheme,
 	stripNewlines,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,7 +457,7 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.0.0:
+acorn-jsx@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
   integrity sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
@@ -472,12 +472,17 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.0.7:
+acorn@^6.0.1:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
   integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
 
-ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
+acorn@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.0.0.tgz#26b8d1cd9a9b700350b71c0905546f64d1284e7a"
+  integrity sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
+
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -679,6 +684,14 @@ array-from@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
   integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-slice@^0.2.3:
   version "0.2.3"
@@ -1725,6 +1738,13 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1845,7 +1865,7 @@ error@^7.0.0, error@^7.0.2:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es-abstract@^1.5.1:
+es-abstract@^1.11.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
   integrity sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
@@ -1921,30 +1941,25 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-3.0.0.tgz#9219a4820719114ed7e9f02c49a51042e0c6cb2b"
-  integrity sha512-8FFCspVYNG44ebP/P4nNpxstWaX+H+JdNOnJjel/Kc5Y4s9rTEXar/xmBARyzU7GTejYxLgNTOqjSy5wrg9Scw==
+eslint-config-liferay@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-10.0.0.tgz#b9d24f673755ac166ffabd62090da80ac6da634d"
+  integrity sha512-mUXoEpzd+r1E12BEzekb3xhwVYe8xY1Zg4YZ8KTZe1emzGYAC1Zf2KXT9Dbit9E7G/qCYQBtVdQWuLO8XKcoVA==
   dependencies:
-    eslint-config-prettier "4.1.0"
-    eslint-plugin-liferayportal "^1.0.0"
+    eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
     eslint-plugin-no-only-tests "^2.1.0"
     eslint-plugin-notice "0.7.8"
+    eslint-plugin-react "7.13.0"
+    eslint-plugin-react-hooks "1.6.0"
+    eslint-plugin-sort-destructure-keys "1.3.3"
 
-eslint-config-prettier@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz#181364895899fff9fd3605fecb5c4f20e7d5f395"
-  integrity sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==
+eslint-config-prettier@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-5.0.0.tgz#f7a94b2b8ae7cbf25842c36fa96c6d32cd0a697c"
+  integrity sha512-c17Aqiz5e8LEqoc/QPmYnaxQFAHTx2KlCZBPxXXjEMmNchOLnV/7j0HoPZuC+rL/tDC9bazUYOKJW9bOhftI/w==
   dependencies:
     get-stdin "^6.0.0"
-
-eslint-plugin-liferayportal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-liferayportal/-/eslint-plugin-liferayportal-1.0.1.tgz#2891b423413db3518a507eda56c664af218635c7"
-  integrity sha512-YOqhDwqtj/K4BSH6ToMMTONHX7VASQoVv2iwPIsetD0aV5DywdTpdj0ZOA8eY9jmhfl+aFbbUjy6jD0YqE2suw==
-  dependencies:
-    requireindex "~1.1.0"
 
 eslint-plugin-no-for-of-loops@^1.0.0:
   version "1.0.0"
@@ -1965,76 +1980,102 @@ eslint-plugin-notice@0.7.8:
     lodash ">=2.4.0"
     metric-lcs "^0.1.2"
 
-eslint-scope@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
-  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+eslint-plugin-react-hooks@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
+eslint-plugin-react@7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.1.0"
+    object.fromentries "^2.0.0"
+    prop-types "^15.7.2"
+    resolve "^1.10.1"
+
+eslint-plugin-sort-destructure-keys@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.3.3.tgz#f8396d1665d1eb70b0ace4972a70dcabadc8d29e"
+  integrity sha512-+ZI4IsCQe1Xfdxo4kTEtXwfHoOOvhV1u6nG7s8Ot1s6KSYlAlx0bnwXSsLgqGzROYkpSAy/a5JI9pPN3pJQXpw==
+  dependencies:
+    natural-compare-lite "^1.4.0"
+
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
+eslint-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
-eslint-visitor-keys@^1.0.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^5.15.2:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.4.0.tgz#5aa9227c3fbe921982b2eda94ba0d7fae858611a"
+  integrity sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^4.0.3"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.2"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.1"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^5.0.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    inquirer "^6.4.1"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.11"
+    lodash "^4.17.14"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    semver "^5.5.1"
-    strip-ansi "^4.0.0"
-    strip-json-comments "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
     table "^5.2.3"
     text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.1.tgz#7f80e5f7257fc47db450022d723e356daeb1e5de"
+  integrity sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==
   dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
+    acorn "^7.0.0"
+    acorn-jsx "^5.0.2"
+    eslint-visitor-keys "^1.1.0"
 
 esprima@2.5.x:
   version "2.5.0"
@@ -2680,6 +2721,13 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-stream@^3.1.5:
   version "3.1.18"
@@ -3545,7 +3593,7 @@ inquirer@^0.12.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^6.0.0, inquirer@^6.2.2, inquirer@^6.3.1:
+inquirer@^6.0.0, inquirer@^6.3.1, inquirer@^6.4.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
   integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
@@ -3752,6 +3800,13 @@ is-glob@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -4428,7 +4483,7 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@3.x, js-yaml@^3.13.0, js-yaml@^3.3.0, js-yaml@^3.9.0:
+js-yaml@3.x, js-yaml@^3.13.1, js-yaml@^3.3.0, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4536,6 +4591,14 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz#4d4973ebf8b9d2837ee91a8208cc66f3a2776cfb"
+  integrity sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==
+  dependencies:
+    array-includes "^3.0.3"
+    object.assign "^4.1.0"
 
 just-extend@^4.0.2:
   version "4.0.2"
@@ -4999,7 +5062,7 @@ lolex@^2.2.0, lolex@^2.3.2:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
   integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5385,6 +5448,11 @@ natives@^1.1.0:
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5628,7 +5696,7 @@ object-assign@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
   integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -5647,7 +5715,7 @@ object-inspect@^1.6.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
   integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -5659,6 +5727,16 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
 object.defaults@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.defaults/-/object.defaults-1.1.0.tgz#3a7f868334b407dea06da16d88d5cd29e435fecf"
@@ -5668,6 +5746,16 @@ object.defaults@^1.1.0:
     array-slice "^1.0.0"
     for-own "^1.0.0"
     isobject "^3.0.0"
+
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  integrity sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -6187,7 +6275,7 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.16.4:
+prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
@@ -6239,6 +6327,15 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
+
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -6318,7 +6415,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.8.4:
+react-is@^16.8.1, react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -6607,11 +6704,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -6657,7 +6749,7 @@ resolve@1.1.7, resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -6836,7 +6928,7 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -6846,7 +6938,7 @@ semver@^4.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
-semver@^6.0.0, semver@^6.2.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -7393,7 +7485,12 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -7884,6 +7981,11 @@ uuid@^3.0.0, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
 v8flags@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
Big update for eslint-config-liferay (from v3.0.0 to v10.0.0), so there are 437 problems to fix (351 of which are autofixable).

The ESLint update is big too (v5.15.2 to v6.4.0) but that only adds one more problem, taking the total to 438.

I'm going to split the autofixable fixes and the manual fixes over the next two commits so that it is clear what they are.

The Prettier update is low key (v1.16.4 to v1.18.2).
