### PR TITLE
chore: update eslint-config-liferay to v11.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "^6.4.0",
-		"eslint-config-liferay": "^11.0.0",
+		"eslint-config-liferay": "^11.0.1",
 		"jest": "^24.1.0",
 		"prettier": "^1.18.2",
 		"sinon": "^4.4.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "^6.4.0",
-		"eslint-config-liferay": "^10.0.0",
+		"eslint-config-liferay": "^11.0.0",
 		"jest": "^24.1.0",
 		"prettier": "^1.18.2",
 		"sinon": "^4.4.6"

--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: MIT
  */
 
+const chaiFs = require('chai-fs');
 const chai = require('chai');
 
 const liferayThemeApp = require('../index');
 
-chai.use(require('chai-fs'));
+chai.use(chaiFs);
+
 const chaiAssert = chai.assert;
 
 describe('liferay-theme:app unit tests', () => {

--- a/packages/generator-liferay-theme/generators/common/messages.js
+++ b/packages/generator-liferay-theme/generators/common/messages.js
@@ -5,7 +5,8 @@
  */
 
 const chalk = require('chalk');
-const version = require('../../package.json').version;
+
+const {version} = require('../../package.json');
 
 function getVersionSupportMessage(generatorNamespace) {
 	const supportedVersion = chalk.red('Liferay DXP and Portal CE v7.2');

--- a/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
+var chaiFs = require('chai-fs');
 var chai = require('chai');
 
-chai.use(require('chai-fs'));
+chai.use(chaiFs);
 
 // TODO: fix functional tests and remove from ignores list
 // var _ = require('lodash');

--- a/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/themelet/__tests__/index.test.js
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: MIT
  */
 
+const chaiFs = require('chai-fs');
 const chai = require('chai');
 const _ = require('lodash');
 
 const liferayThemeThemelet = require('../index');
 
-chai.use(require('chai-fs'));
+chai.use(chaiFs);
+
 const assert = chai.assert;
 
 describe('liferay-theme:themelet unit tests', () => {

--- a/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/layout_creator.test.js
@@ -12,10 +12,10 @@ const path = require('path');
 const sinon = require('sinon');
 const stripAnsi = require('strip-ansi');
 
+const LayoutCreator = require('../../lib/layout_creator');
+
 const assert = chai.assert;
 const sinonAssert = sinon.assert;
-
-const LayoutCreator = require('../../lib/layout_creator');
 
 describe('LayoutCreator', () => {
 	var prototype;

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -6,15 +6,18 @@
 
 'use strict';
 
-require('./lib/checkNodeVersion')();
-
 const globby = require('globby');
-const plugins = require('gulp-load-plugins')();
+const gulpLoadPlugins = require('gulp-load-plugins');
 const _ = require('lodash');
 const path = require('path');
 
+const checkNodeVersion = require('./lib/checkNodeVersion');
 const lfrThemeConfig = require('./lib/liferay_theme_config');
 const pluginTasks = require('./plugin');
+
+checkNodeVersion();
+
+const plugins = gulpLoadPlugins();
 
 const themeConfig = lfrThemeConfig.getConfig();
 

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -9,12 +9,11 @@
 require('./lib/checkNodeVersion')();
 
 const globby = require('globby');
+const plugins = require('gulp-load-plugins')();
 const _ = require('lodash');
 const path = require('path');
 
 const lfrThemeConfig = require('./lib/liferay_theme_config');
-const plugins = require('gulp-load-plugins')();
-
 const pluginTasks = require('./plugin');
 
 const themeConfig = lfrThemeConfig.getConfig();

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -155,8 +155,7 @@ function mergeLookAndFeelJSON(themePath, lookAndFeelJSON, cb) {
 		}
 
 		// eslint-disable-next-line liferay/no-dynamic-require
-		const themeInfo = require(path.join(themePath, 'package.json'))
-			.liferayTheme;
+		const {liferayTheme: themeInfo} = require(path.join(themePath, 'package.json'));
 
 		const baseTheme = themeInfo.baseTheme;
 

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -157,7 +157,10 @@ function mergeLookAndFeelJSON(themePath, lookAndFeelJSON, cb) {
 		}
 
 		// eslint-disable-next-line liferay/no-dynamic-require
-		const {liferayTheme: themeInfo} = require(path.join(themePath, 'package.json'));
+		const {liferayTheme: themeInfo} = require(path.join(
+			themePath,
+			'package.json'
+		));
 
 		const baseTheme = themeInfo.baseTheme;
 

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -10,7 +10,9 @@ const path = require('path');
 const util = require('util');
 const xml2js = require('xml2js');
 
-const {pathSrc} = require('./options')();
+const options = require('./options');
+
+const {pathSrc} = options();
 
 const QUERY_ELEMENTS = {
 	'color-scheme': 'id',

--- a/packages/liferay-theme-tasks/lib/war_deployer.js
+++ b/packages/liferay-theme-tasks/lib/war_deployer.js
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const EventEmitter = require('events').EventEmitter;
-
 const colors = require('ansi-colors');
+const {EventEmitter} = require('events');
 const log = require('fancy-log');
 const fs = require('fs');
 const inquirer = require('inquirer');

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-var EventEmitter = require('events').EventEmitter;
+var {EventEmitter} = require('events');
 
 module.exports = function(gulp) {
 	gulp.hook('before:build', () => {

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -15,9 +15,9 @@ var os = require('os');
 var path = require('path');
 var sinon = require('sinon');
 
-var gulp = new Gulp();
-
 var {getArgv} = require('../../lib/util');
+
+var gulp = new Gulp();
 
 chai.use(chaiFs);
 

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+var chaiFs = require('chai-fs');
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
@@ -14,11 +15,11 @@ var os = require('os');
 var path = require('path');
 var sinon = require('sinon');
 
-var {getArgv} = require('../../lib/util');
-
 var gulp = new Gulp();
 
-chai.use(require('chai-fs'));
+var {getArgv} = require('../../lib/util');
+
+chai.use(chaiFs);
 
 var assert = chai.assert;
 

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -9,8 +9,7 @@
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
-var Gulp = require('gulp').Gulp;
-
+var {Gulp} = require('gulp');
 var os = require('os');
 var path = require('path');
 var sinon = require('sinon');

--- a/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
@@ -7,10 +7,9 @@
 'use strict';
 
 var async = require('async');
+var {EventEmitter} = require('events');
 var gutil = require('gulp-util');
-var EventEmitter = require('events').EventEmitter;
-var Gulp = require('gulp').Gulp;
-
+var {Gulp} = require('gulp');
 var _ = require('lodash');
 var path = require('path');
 var sinon = require('sinon');

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -9,8 +9,7 @@
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
-var Gulp = require('gulp').Gulp;
-
+var {Gulp} = require('gulp');
 var os = require('os');
 var path = require('path');
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -12,10 +12,10 @@ var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
+var path = require('path');
 
 var gulp = new Gulp();
 
-var path = require('path');
 
 chai.use(chaiFs);
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -16,7 +16,6 @@ var path = require('path');
 
 var gulp = new Gulp();
 
-
 chai.use(chaiFs);
 
 var assert = chai.assert;

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -6,16 +6,18 @@
 
 'use strict';
 
+var chaiFs = require('chai-fs');
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
-var path = require('path');
 
 var gulp = new Gulp();
 
-chai.use(require('chai-fs'));
+var path = require('path');
+
+chai.use(chaiFs);
 
 var assert = chai.assert;
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/init.js
@@ -8,9 +8,8 @@
 
 var del = require('del');
 var fs = require('fs-extra');
+var {Gulp} = require('gulp');
 var _ = require('lodash');
-var Gulp = require('gulp').Gulp;
-
 var os = require('os');
 var path = require('path');
 var sinon = require('sinon');

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -9,8 +9,7 @@
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
-var Gulp = require('gulp').Gulp;
-
+var {Gulp} = require('gulp');
 var os = require('os');
 var path = require('path');
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -12,10 +12,10 @@ var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
+var path = require('path');
 
 var gulp = new Gulp();
 
-var path = require('path');
 
 chai.use(chaiFs);
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -16,7 +16,6 @@ var path = require('path');
 
 var gulp = new Gulp();
 
-
 chai.use(chaiFs);
 
 var assert = chai.assert;

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -6,16 +6,18 @@
 
 'use strict';
 
+var chaiFs = require('chai-fs');
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
-var path = require('path');
 
 var gulp = new Gulp();
 
-chai.use(require('chai-fs'));
+var path = require('path');
+
+chai.use(chaiFs);
 
 var assert = chai.assert;
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -9,8 +9,7 @@
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
-var Gulp = require('gulp').Gulp;
-
+var {Gulp} = require('gulp');
 var os = require('os');
 var path = require('path');
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -12,10 +12,10 @@ var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
+var path = require('path');
 
 var gulp = new Gulp();
 
-var path = require('path');
 
 chai.use(chaiFs);
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -16,7 +16,6 @@ var path = require('path');
 
 var gulp = new Gulp();
 
-
 chai.use(chaiFs);
 
 var assert = chai.assert;

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -6,16 +6,18 @@
 
 'use strict';
 
+var chaiFs = require('chai-fs');
 var chai = require('chai');
 var del = require('del');
 var fs = require('fs-extra');
 var {Gulp} = require('gulp');
 var os = require('os');
-var path = require('path');
 
 var gulp = new Gulp();
 
-chai.use(require('chai-fs'));
+var path = require('path');
+
+chai.use(chaiFs);
 
 var assert = chai.assert;
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -5,10 +5,9 @@
  */
 
 const fs = require('fs-extra');
-const parseString = require('xml2js').parseString;
-
 const path = require('path');
 const sinon = require('sinon');
+const {parseString} = require('xml2js');
 
 const testUtil = require('../../test/util');
 

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -8,10 +8,9 @@
 
 const del = require('del');
 const fs = require('fs-extra');
+const plugins = require('gulp-load-plugins')();
 const replace = require('gulp-replace-task');
 const _ = require('lodash');
-const plugins = require('gulp-load-plugins')();
-
 const path = require('path');
 const PluginError = require('plugin-error');
 const through = require('through2');

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -8,7 +8,7 @@
 
 const del = require('del');
 const fs = require('fs-extra');
-const plugins = require('gulp-load-plugins')();
+const gulpLoadPlugins = require('gulp-load-plugins');
 const replace = require('gulp-replace-task');
 const _ = require('lodash');
 const path = require('path');
@@ -20,6 +20,8 @@ const lfrThemeConfig = require('../lib/liferay_theme_config');
 const lookAndFeelUtil = require('../lib/look_and_feel_util');
 const normalize = require('../lib/normalize');
 const themeUtil = require('../lib/util');
+
+const plugins = gulpLoadPlugins();
 
 const themeConfig = lfrThemeConfig.getConfig();
 

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -10,10 +10,9 @@ const colors = require('ansi-colors');
 const async = require('async');
 const log = require('fancy-log');
 const fs = require('fs');
+const plugins = require('gulp-load-plugins')();
 const _ = require('lodash');
 const path = require('path');
-const plugins = require('gulp-load-plugins')();
-
 const vinylPaths = require('vinyl-paths');
 
 const lfrThemeConfig = require('../../lib/liferay_theme_config');

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -10,12 +10,14 @@ const colors = require('ansi-colors');
 const async = require('async');
 const log = require('fancy-log');
 const fs = require('fs');
-const plugins = require('gulp-load-plugins')();
+const gulpLoadPlugins = require('gulp-load-plugins');
 const _ = require('lodash');
 const path = require('path');
 const vinylPaths = require('vinyl-paths');
 
 const lfrThemeConfig = require('../../lib/liferay_theme_config');
+
+const plugins = gulpLoadPlugins();
 
 const themeConfig = lfrThemeConfig.getConfig();
 

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -6,9 +6,8 @@
 
 const del = require('del');
 const fs = require('fs-extra');
+const {Gulp} = require('gulp');
 const _ = require('lodash');
-const Gulp = require('gulp').Gulp;
-
 const os = require('os');
 const path = require('path');
 const sinon = require('sinon');
@@ -248,7 +247,7 @@ function copyTempTheme(options) {
 	if (options.registerTasksOptions || options.registerTasks) {
 		deleteJsFromCache();
 
-		const registerTasks = require('../index.js').registerTasks;
+		const {registerTasks} = require('../index.js');
 
 		gulp = new Gulp();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,10 +1941,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-10.0.0.tgz#b9d24f673755ac166ffabd62090da80ac6da634d"
-  integrity sha512-mUXoEpzd+r1E12BEzekb3xhwVYe8xY1Zg4YZ8KTZe1emzGYAC1Zf2KXT9Dbit9E7G/qCYQBtVdQWuLO8XKcoVA==
+eslint-config-liferay@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-11.0.0.tgz#17ce7a9df22bbc23d3e4304b34225c3af2d5f513"
+  integrity sha512-II92IOpCxmDgLM2fIji6KYwpFJD/BoABb0bq78FLfkq+//W4eErwyRpZcxtsdh7ydmi67ILj3NqMSXwVZC374w==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,10 +1941,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-11.0.0.tgz#17ce7a9df22bbc23d3e4304b34225c3af2d5f513"
-  integrity sha512-II92IOpCxmDgLM2fIji6KYwpFJD/BoABb0bq78FLfkq+//W4eErwyRpZcxtsdh7ydmi67ILj3NqMSXwVZC374w==
+eslint-config-liferay@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-11.0.1.tgz#08973ef4c6461e961a13b12623e19faed78ae8b7"
+  integrity sha512-3kS4RjqcJE1QgOExSx/qmP9/n7+wYjvu/Ss8INjd+MxKEO7dvqvGlfaDc87QJgrISb3SyO12R9HFncLBBpRpdg==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
New:

- destructure-requires
- imports-first (this one was in eslint-config-liferay v10.0.0 but not turned on by default).
- no-require-and-call