### PR TITLE
fix: correct misspelled function in layout generator (#409)

### DIFF
--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -61,7 +61,7 @@ module.exports = class extends Base {
 			fs.stat(themePackagePath, (err, stat) => {
 				if (!err && stat.isFile()) {
 					const themePackage = JSON.parse(
-						fs.readfileSync(themePackagePath, 'utf8')
+						fs.readFileSync(themePackagePath, 'utf8')
 					);
 
 					if (themePackage.liferayTheme) {


### PR DESCRIPTION
Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/409