### PR TITLE
fix: make layout generator produce correct paths on Windows (#412)

### DIFF
--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -65,7 +65,7 @@ module.exports = class extends Base {
 					);
 
 					if (themePackage.liferayTheme) {
-						layoutDirName = path.join(
+						layoutDirName = path.posix.join(
 							'src/layouttpl/custom',
 							layoutDirName
 						);


### PR DESCRIPTION
`yo liferay-theme:layout` was producing `liferay-layout-templates.xml` files with bad paths like:

    <template-path>\layouttpl\custom\foo-layouttpl/foo.ftl</template-path>

instead of:

    <template-path>/layouttpl/custom/foo-layouttpl/foo.ftl</template-path>

leading to a runtime error on Windows when deploying.

You can see in our template files that we should always be using POSIX path separators:

https://github.com/liferay/liferay-js-themes-toolkit/blob/bdad65c47130f09193a66baad982e01f32cebd2e/packages/generator-liferay-theme/generators/layout/templates/docroot/WEB-INF/liferay-layout-templates.xml#L7-L8

Ideally this regression(?) would have been caught by our test suite, but the related functional tests are disabled right now and have been since c3c4e9a6:

https://github.com/liferay/liferay-js-themes-toolkit/blob/bdad65c47130f09193a66baad982e01f32cebd2e/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js#L40-L47

Test plan:

Run `yo liferay-theme` to create a theme; `cd` into generated theme directory and run `yo liferay-theme:layout`; verify `src/WEB-INF/liferay-layout-templates.xml` is well-formed:

    <?xml version="1.0"?>
    <!DOCTYPE layout-templates PUBLIC "-//Liferay//DTD Layout Templates 7.2.0//EN" "http://www.liferay.com/dtd/liferay-layout-templates_7_2_0.dtd">

    <layout-templates>
            <custom>
                    <layout-template id="my-liferay-layout" name="My Liferay Layout">
                            <template-path>/layouttpl/custom/my-liferay-layout-layouttpl/my_liferay_layout.ftl</template-path>
                            <thumbnail-path>/layouttpl/custom/my-liferay-layout-layouttpl/my_liferay_layout.png</thumbnail-path>
                    </layout-template>
            </custom>
    </layout-templates>

Also see the original ticket where we verified that this change works on Windows.

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/412