### PR TITLE
style: fix mangled changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,501 @@
-## [v9.5.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.5.0) (2020-01-30)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.5.0-beta.0...v9.5.0)-   feat: add final theme thumbnail placeholder (#103) ([\#434](https://github.com/liferay/liferay-js-themes-toolkit/pull/434))-   fix: exclude .css files when extracting classic/admin theme (#432)    ([\#433](https://github.com/liferay/liferay-js-themes-toolkit/pull/433))-   docs: explain the role of PR titles in changelog generation ([\#430](https://github.com/liferay/liferay-js-themes-toolkit/pull/430))## [v9.5.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.5.0-beta.0) (2020-01-24)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.3...v9.5.0-beta.0)-   feat: support Liferay DXP 7.3 (#415), enhance R2 error reporting (#417), and provide npm scripts for gulp tasks (#381) ([\#422](https://github.com/liferay/liferay-js-themes-toolkit/pull/422))-   feat: support themes based on Liferay's Classic Theme (#419) ([\#425](https://github.com/liferay/liferay-js-themes-toolkit/pull/425))-   feat: support themes based on Liferay's Admin Theme (#423) ([\#426](https://github.com/liferay/liferay-js-themes-toolkit/pull/426))-   fix: extend from themelets using package URLs (#375) ([\#427](https://github.com/liferay/liferay-js-themes-toolkit/pull/427))-   feat: generate placeholder thumbnail.png file (#103) ([\#428](https://github.com/liferay/liferay-js-themes-toolkit/pull/428))## [v9.4.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.3) (2019-12-12)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.2...v9.4.3)-   fix: make layout generator produce correct paths on Windows (#412) ([\#413](https://github.com/liferay/liferay-js-themes-toolkit/pull/413))## [v9.4.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.2) (2019-12-11)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.1...v9.4.2)-   fix: correct misspelled function in layout generator (#409) ([\#410](https://github.com/liferay/liferay-js-themes-toolkit/pull/410))## [v9.4.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.1) (2019-11-25)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.0...v9.4.1)-   chore: update dependencies ([\#401](https://github.com/liferay/liferay-js-themes-toolkit/pull/401))-   chore: upgrade dependencies ([\#397](https://github.com/liferay/liferay-js-themes-toolkit/pull/397))-   chore: update eslint-config-liferay to v11.0.1 ([\#394](https://github.com/liferay/liferay-js-themes-toolkit/pull/394))-   chore: update eslint, eslint-config-liferay, prettier ([\#393](https://github.com/liferay/liferay-js-themes-toolkit/pull/393))-   chore: update dependencies ([\#391](https://github.com/liferay/liferay-js-themes-toolkit/pull/391))-   chore: use liferay-changelog-generator instead of scripts/changelog.js ([\#389](https://github.com/liferay/liferay-js-themes-toolkit/pull/389))-   feat: configure Semantic Pull Requests bot ([\#385](https://github.com/liferay/liferay-js-themes-toolkit/pull/385))## [v9.4.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.0) (2019-08-05)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.3.0...v9.4.0)-   feat: add font-awesome in upgrade process ([\#382](https://github.com/liferay/liferay-js-themes-toolkit/pull/382))## [v9.3.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.3.0) (2019-07-22)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.2.1...v9.3.0)-   feat: add support for font awesome on theme creation ([\#377](https://github.com/liferay/liferay-js-themes-toolkit/pull/377))## [v9.2.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.2.1) (2019-07-02)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.2.0...v9.2.1)-   fix: silent `npm install` failures on Windows in extend and kickstart ([\#370](https://github.com/liferay/liferay-js-themes-toolkit/pull/370))-   fix: Windows compatibility extending themes via URL (#365) ([\#369](https://github.com/liferay/liferay-js-themes-toolkit/pull/369))## [v9.2.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.2.0) (2019-06-27)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.5...v9.2.0)-   feat: teach `gulp extend` to accept a package URL (9.x) (#266) ([\#333](https://github.com/liferay/liferay-js-themes-toolkit/pull/333))## [v9.1.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.5) (2019-06-24)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.4...v9.1.5)-   fix: prevent proxy errors from killing the watcher ([\#358](https://github.com/liferay/liferay-js-themes-toolkit/pull/358))## [v9.1.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.4) (2019-06-11)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.3...v9.1.4)-   chore: strictly peg dependency versions (#352) ([\#353](https://github.com/liferay/liferay-js-themes-toolkit/pull/353))-   fix: Fix typo in JS MIME type (9.x) (#349) ([\#351](https://github.com/liferay/liferay-js-themes-toolkit/pull/351))## [v9.1.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.3) (2019-06-06)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.2...v9.1.3)-   fix(tasks): non-CSS/JS file changes break CSS when using "watch" (#340) ([\#345](https://github.com/liferay/liferay-js-themes-toolkit/pull/345))-   feat: add a runtime NodeJS version check (#339) ([\#343](https://github.com/liferay/liferay-js-themes-toolkit/pull/343))-   chore: Update theme dependencies for Liferay 7.2 release (#341) ([\#342](https://github.com/liferay/liferay-js-themes-toolkit/pull/342))-   chore: remove backup/revert functionality (9.x) (#267) ([\#286](https://github.com/liferay/liferay-js-themes-toolkit/pull/286))-   feat: handle lightweight tags in changelog script ([\#335](https://github.com/liferay/liferay-js-themes-toolkit/pull/335))## [v9.1.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.2) (2019-04-17)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.1...v9.1.2)-   perf: avoid unnecessary buffering of responses in watch mode (#324) ([\#325](https://github.com/liferay/liferay-js-themes-toolkit/pull/325))-   fix: invalid "this" in deploy-live:war task (9.x) ([\#322](https://github.com/liferay/liferay-js-themes-toolkit/pull/322))## [v9.1.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.1) (2019-04-12)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.0...v9.1.1)-   doc: add v7 to the compatibility table (9.x) (#313) ([\#317](https://github.com/liferay/liferay-js-themes-toolkit/pull/317))-   fix: make "watch" mode work with portal gzipped (#311) ([\#314](https://github.com/liferay/liferay-js-themes-toolkit/pull/314))-   fix: broken CSS and sign-in when using "watch" proxy (#309, #310) ([\#312](https://github.com/liferay/liferay-js-themes-toolkit/pull/312))## [v9.1.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.0) (2019-04-10)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0...v9.1.0)-   feat: teach theme tasks to accept `--sass-include-paths` option (#305) ([\#306](https://github.com/liferay/liferay-js-themes-toolkit/pull/306))## [v9.0.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0) (2019-04-09)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-beta.1...v9.0.0)-   feat: auto-deploy when starting `gulp watch` (#291) ([\#299](https://github.com/liferay/liferay-js-themes-toolkit/pull/299))-   fix: failure to update after non-JS/CSS changes in watch mode (#291) ([\#297](https://github.com/liferay/liferay-js-themes-toolkit/pull/297))## [v9.0.0-beta.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-beta.1) (2019-04-09)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-beta.0...v9.0.0-beta.1)-   doc: remove Gulp entry from version table (v9.x) ([\#294](https://github.com/liferay/liferay-js-themes-toolkit/pull/294))-   feat: add ability to config PostCSS plug-ins (9.x) (#126) ([\#289](https://github.com/liferay/liferay-js-themes-toolkit/pull/289))-   fix: silent failures when using autoprefixer (9.x) (#274) ([\#287](https://github.com/liferay/liferay-js-themes-toolkit/pull/287))## [v9.0.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-beta.0) (2019-04-03)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-alpha.1...v9.0.0-beta.0)-   feat: print watch info when starting watch (#277) ([\#278](https://github.com/liferay/liferay-js-themes-toolkit/pull/278))-   fix: make it harder to accidentally produce duplicate entries in changelog ([\#276](https://github.com/liferay/liferay-js-themes-toolkit/pull/276))-   feat: automatically prefetch tags before running changelog generator ([\#275](https://github.com/liferay/liferay-js-themes-toolkit/pull/275))-   doc: remove stale references to Visual Studio (#271) ([\#272](https://github.com/liferay/liferay-js-themes-toolkit/pull/272))-   feat: teach the changelog generator to correct errors with "v" prefix ([\#243](https://github.com/liferay/liferay-js-themes-toolkit/pull/243))-   fix: broken links in generated changelog ([\#242](https://github.com/liferay/liferay-js-themes-toolkit/pull/242))## [v9.0.0-alpha.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-alpha.1) (2019-03-21)[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-alpha.0...v9.0.0-alpha.1)-   Create new changelog generator and use it to create 9.0.0-alpha.1 changelog ([\#239](https://github.com/liferay/liferay-js-themes-toolkit/pull/239))-   Make `gulp watch` pick up changes in subdirectories (v8.x) ([\#237](https://github.com/liferay/liferay-js-themes-toolkit/pull/237))## [v9.0.0-alpha.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-alpha.0) (2019-03-19)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0...v9.0.0-alpha.0)**Breaking changes:**-   Version 9 is a streamlined and modernized toolkit, focusing exclusively on generating themes, layouts and themelets for Liferay DXP and Portal CE 7.2. At the same time, we just released [version 8.0.0 of the toolkit](https://github.com/liferay/liferay-js-themes-toolkit/releases/tag/v8.0.0) that provides tools for working with Liferay DXP and Portal CE versions 7.0 and 7.1 (#184).**Other changes:**-   Themes are now generated with their dependencies explicitly listed in the "package.json" as opposed to being included transitively via a "liferay-theme-deps" package as was the case in version 8 (#168).## [v8.0.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0) (2019-03-18)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.3...v8.0.0)**Implemented enhancements:**-   Use prettier to format all eligible files, not just JS [\#151](https://github.com/liferay/liferay-js-themes-toolkit/issues/151)-   Migrate to Yarn [\#149](https://github.com/liferay/liferay-js-themes-toolkit/issues/149)-   Layouts sub-generator should generate FTL layout template file [\#129](https://github.com/liferay/liferay-js-themes-toolkit/issues/129)-   Make `watch` task more robust [\#127](https://github.com/liferay/liferay-js-themes-toolkit/issues/127)-   Cannot update packages caused by vulnerabilities for newly created theme [\#70](https://github.com/liferay/liferay-js-themes-toolkit/issues/70)-   Use Prettier to format all eligible files [\#153](https://github.com/liferay/liferay-js-themes-toolkit/pull/153) ([wincent](https://github.com/wincent))**Fixed bugs:**-   Remove generator dependence on globally installed gulp instance [\#172](https://github.com/liferay/liferay-js-themes-toolkit/issues/172)-   Imports with lexicon- prefix are not upgraded properly to 7.1 [\#143](https://github.com/liferay/liferay-js-themes-toolkit/issues/143)-   Erroneous update message: Update available 8.0.0-beta.1 → 8.0.0-beta.5 [\#92](https://github.com/liferay/liferay-js-themes-toolkit/issues/92)-   Add proper outbound licensing [\#48](https://github.com/liferay/liferay-js-themes-toolkit/issues/48)-   Fix post-install for layout generator [\#194](https://github.com/liferay/liferay-js-themes-toolkit/pull/194) ([wincent](https://github.com/wincent))-   Rename SDK reference to "toolkit" [\#186](https://github.com/liferay/liferay-js-themes-toolkit/pull/186) ([wincent](https://github.com/wincent))-   Overhaul normalize processing [\#178](https://github.com/liferay/liferay-js-themes-toolkit/pull/178) ([wincent](https://github.com/wincent))-   Remove generator dependence on globally installed gulp instance \(\#172\) [\#173](https://github.com/liferay/liferay-js-themes-toolkit/pull/173) ([wincent](https://github.com/wincent))**Closed issues:**-   Send the correct MIME type header when watching [\#208](https://github.com/liferay/liferay-js-themes-toolkit/issues/208)-   Retire doctor [\#196](https://github.com/liferay/liferay-js-themes-toolkit/issues/196)-   Fold liferay-plugin-node-tasks into liferay-theme-tasks [\#193](https://github.com/liferay/liferay-js-themes-toolkit/issues/193)-   Rename to liferay-js-themes-toolkit [\#185](https://github.com/liferay/liferay-js-themes-toolkit/issues/185)-   Clarify "compatibility matrix" between versions of liferay-js-themes-toolkit and Liferay DXP and Portal CE [\#184](https://github.com/liferay/liferay-js-themes-toolkit/issues/184)-   Add LICENSE.md files [\#169](https://github.com/liferay/liferay-js-themes-toolkit/issues/169)-   \[RFC\] Eliminate liferay-theme-deps-\* packages [\#168](https://github.com/liferay/liferay-js-themes-toolkit/issues/168)-   Fold liferay-theme-finder package into main SDK package [\#166](https://github.com/liferay/liferay-js-themes-toolkit/issues/166)-   Unwind some aspects of monorepoization [\#164](https://github.com/liferay/liferay-js-themes-toolkit/issues/164)-   Provide content for top-level README.md [\#154](https://github.com/liferay/liferay-js-themes-toolkit/issues/154)-   Drop rubySass support [\#152](https://github.com/liferay/liferay-js-themes-toolkit/issues/152)-   8.0.0-rc.4 [\#146](https://github.com/liferay/liferay-js-themes-toolkit/issues/146)-   Gulp watch doesn't work correctly when making a change on scss file [\#142](https://github.com/liferay/liferay-js-themes-toolkit/issues/142)-   Liferay Theme Dependencies uses a version of Lodash that is vulnerable to CVE-2018-3721 [\#141](https://github.com/liferay/liferay-js-themes-toolkit/issues/141)-   gulp watch with docker does not change the code [\#136](https://github.com/liferay/liferay-js-themes-toolkit/issues/136)-   7.1 Theme build fails due to missing import [\#128](https://github.com/liferay/liferay-js-themes-toolkit/issues/128)-   gulp watch fail to install theme bundle if you have liferay-hook.xml in WEB-INF [\#120](https://github.com/liferay/liferay-js-themes-toolkit/issues/120)-   gulp watch not taking correct version number [\#107](https://github.com/liferay/liferay-js-themes-toolkit/issues/107)-   make created folder name more readable from "yo liferay-theme:layout" [\#101](https://github.com/liferay/liferay-js-themes-toolkit/issues/101)-   Upgrade default dependencies [\#97](https://github.com/liferay/liferay-js-themes-toolkit/issues/97)-   gulp watch broken on Windows 10 [\#95](https://github.com/liferay/liferay-js-themes-toolkit/issues/95)**Merged pull requests:**-   Clean out packages directory [\#218](https://github.com/liferay/liferay-js-themes-toolkit/pull/218) ([wincent](https://github.com/wincent))-   Address some yarn audit issues \(for toolkit v9\) [\#217](https://github.com/liferay/liferay-js-themes-toolkit/pull/217) ([wincent](https://github.com/wincent))-   Address some yarn audit issues \(for toolkit v8\) \(\#199\) [\#216](https://github.com/liferay/liferay-js-themes-toolkit/pull/216) ([wincent](https://github.com/wincent))-   Remove unused "doctor" fixtures [\#215](https://github.com/liferay/liferay-js-themes-toolkit/pull/215) ([wincent](https://github.com/wincent))-   Fold liferay-plugin-node-tasks into liferay-theme-tasks [\#213](https://github.com/liferay/liferay-js-themes-toolkit/pull/213) ([wincent](https://github.com/wincent))-   Kill dead watch_socket.js and gogo-shell code \(v9\) [\#212](https://github.com/liferay/liferay-js-themes-toolkit/pull/212) ([wincent](https://github.com/wincent))-   Kill dead watch_socket.js and gogo-shell code [\#211](https://github.com/liferay/liferay-js-themes-toolkit/pull/211) ([wincent](https://github.com/wincent))-   Update template paths [\#210](https://github.com/liferay/liferay-js-themes-toolkit/pull/210) ([julien](https://github.com/julien))-   Send correct MIME type \(Content-Type\) header for local css files [\#209](https://github.com/liferay/liferay-js-themes-toolkit/pull/209) ([julien](https://github.com/julien))-   Fix "packageVersion is not defined" generator an "All" themelet [\#207](https://github.com/liferay/liferay-js-themes-toolkit/pull/207) ([wincent](https://github.com/wincent))-   Remove incomplete DXP and Portal CE 7.2 support from v8 of toolkit [\#206](https://github.com/liferay/liferay-js-themes-toolkit/pull/206) ([wincent](https://github.com/wincent))-   Add license headers to files [\#203](https://github.com/liferay/liferay-js-themes-toolkit/pull/203) ([wincent](https://github.com/wincent))-   Add LICENSE.md files [\#202](https://github.com/liferay/liferay-js-themes-toolkit/pull/202) ([wincent](https://github.com/wincent))-   Apply clean-up to new "watch" implementation [\#201](https://github.com/liferay/liferay-js-themes-toolkit/pull/201) ([julien](https://github.com/julien))-   Provide content for top-level README.md \(v8\) [\#200](https://github.com/liferay/liferay-js-themes-toolkit/pull/200) ([wincent](https://github.com/wincent))-   Update references to old repository name \(v8\) [\#197](https://github.com/liferay/liferay-js-themes-toolkit/pull/197) ([wincent](https://github.com/wincent))-   Update yeoman-generator v0.18.0 to 3.2.0 \(for v8 of toolkit\) [\#195](https://github.com/liferay/liferay-js-themes-toolkit/pull/195) ([wincent](https://github.com/wincent))-   Update yeoman-generator v0.18.0 to 3.2.0 \(for v9 of toolkit\) [\#192](https://github.com/liferay/liferay-js-themes-toolkit/pull/192) ([wincent](https://github.com/wincent))-   Remove nested .travis.yml file [\#191](https://github.com/liferay/liferay-js-themes-toolkit/pull/191) ([wincent](https://github.com/wincent))-   Make `watch` task more robust \(2nd approach\) [\#190](https://github.com/liferay/liferay-js-themes-toolkit/pull/190) ([julien](https://github.com/julien))-   Prepare for v8/v9 split [\#187](https://github.com/liferay/liferay-js-themes-toolkit/pull/187) ([wincent](https://github.com/wincent))-   Address security issues reported by "yarn audit" [\#183](https://github.com/liferay/liferay-js-themes-toolkit/pull/183) ([wincent](https://github.com/wincent))-   Update eslint and eslint-config-liferay to latest [\#181](https://github.com/liferay/liferay-js-themes-toolkit/pull/181) ([wincent](https://github.com/wincent))-   Don't use string-concatenation to build up devDependencies [\#180](https://github.com/liferay/liferay-js-themes-toolkit/pull/180) ([wincent](https://github.com/wincent))-   Replace the "divert\(\)" abstraction with something simpler [\#179](https://github.com/liferay/liferay-js-themes-toolkit/pull/179) ([wincent](https://github.com/wincent))-   Freshen lockfile [\#177](https://github.com/liferay/liferay-js-themes-toolkit/pull/177) ([wincent](https://github.com/wincent))-   Remove unnecessary dynamism of getDependencyName [\#176](https://github.com/liferay/liferay-js-themes-toolkit/pull/176) ([wincent](https://github.com/wincent))-   Remove scary warnings from normalize process in the generator [\#175](https://github.com/liferay/liferay-js-themes-toolkit/pull/175) ([wincent](https://github.com/wincent))-   Remove deprecated liferay-theme-finder package [\#167](https://github.com/liferay/liferay-js-themes-toolkit/pull/167) ([wincent](https://github.com/wincent))-   Fold "divert" into liferay-theme-tasks [\#165](https://github.com/liferay/liferay-js-themes-toolkit/pull/165) ([wincent](https://github.com/wincent))-   Remove \_.isPlainObject calls in divert.js \(x2\) [\#163](https://github.com/liferay/liferay-js-themes-toolkit/pull/163) ([wincent](https://github.com/wincent))-   Format even more files with prettier [\#162](https://github.com/liferay/liferay-js-themes-toolkit/pull/162) ([wincent](https://github.com/wincent))-   Update lerna, and let it know that we are using Yarn workspaces [\#160](https://github.com/liferay/liferay-js-themes-toolkit/pull/160) ([wincent](https://github.com/wincent))-   Remove lodash from liferay-theme-finder [\#159](https://github.com/liferay/liferay-js-themes-toolkit/pull/159) ([wincent](https://github.com/wincent))-   Fixes \#147 | Add support for 7.2 themes [\#158](https://github.com/liferay/liferay-js-themes-toolkit/pull/158) ([julien](https://github.com/julien))-   Remove update-notifier functionality [\#156](https://github.com/liferay/liferay-js-themes-toolkit/pull/156) ([wincent](https://github.com/wincent))-   Remove rubySass [\#155](https://github.com/liferay/liferay-js-themes-toolkit/pull/155) ([wincent](https://github.com/wincent))-   Migrate to Yarn [\#150](https://github.com/liferay/liferay-js-themes-toolkit/pull/150) ([wincent](https://github.com/wincent))-   Fixes \#128 - Imports compat/mixins to add missing BS3 mixins used in base files [\#145](https://github.com/liferay/liferay-js-themes-toolkit/pull/145) ([jbalsas](https://github.com/jbalsas))-   Fixes \#143 - Replaces lexicon- prefix from lexicon-base occurrences [\#144](https://github.com/liferay/liferay-js-themes-toolkit/pull/144) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-rc.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.3) (2019-02-13)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.2...v8.0.0-rc.3)**Closed issues:**-   TypeError thrown when upgrading a theme from 7.0 to 7.1 with 8.0.0-rc.2 [\#138](https://github.com/liferay/liferay-js-themes-toolkit/issues/138)-   Remove `ruby-sass` option from Theme Generator as it's no longer required for Windows [\#137](https://github.com/liferay/liferay-js-themes-toolkit/issues/137)**Merged pull requests:**-   Fixes \#137 - Updates theme deps versions [\#140](https://github.com/liferay/liferay-js-themes-toolkit/pull/140) ([jbalsas](https://github.com/jbalsas))-   Fixes \#138 - Adds bootstrap log buffer [\#139](https://github.com/liferay/liferay-js-themes-toolkit/pull/139) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-rc.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.2) (2019-01-28)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.1...v8.0.0-rc.2)**Fixed bugs:**-   Gulp upgrade changes camel-case to kebab-case only within some files [\#133](https://github.com/liferay/liferay-js-themes-toolkit/issues/133)-   TypeError: colors.bgblack is not a function in liferay-theme-tasks/lib/upgrade/7.0/upgrade.js:482:30\) [\#125](https://github.com/liferay/liferay-js-themes-toolkit/issues/125)-   gulp kickstart unable to find globally installed themes [\#100](https://github.com/liferay/liferay-js-themes-toolkit/issues/100)-   Building an extended theme doesn't add the parent theme files [\#11](https://github.com/liferay/liferay-js-themes-toolkit/issues/11)**Merged pull requests:**-   v.8.0.0-rc.2 [\#135](https://github.com/liferay/liferay-js-themes-toolkit/pull/135) ([jbalsas](https://github.com/jbalsas))-   Fixes \#133 - Updated lock files [\#134](https://github.com/liferay/liferay-js-themes-toolkit/pull/134) ([jbalsas](https://github.com/jbalsas))-   Fixes \#10 - SF [\#132](https://github.com/liferay/liferay-js-themes-toolkit/pull/132) ([jbalsas](https://github.com/jbalsas))-   Fix for the theme extension bug [\#131](https://github.com/liferay/liferay-js-themes-toolkit/pull/131) ([GianBe](https://github.com/GianBe))## [v8.0.0-rc.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.1) (2018-12-12)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.0...v8.0.0-rc.1)**Fixed bugs:**-   Programatically created Bourbon file breaks sourcemap [\#83](https://github.com/liferay/liferay-js-themes-toolkit/issues/83)**Merged pull requests:**-   v8.0.0-rc.1 [\#122](https://github.com/liferay/liferay-js-themes-toolkit/pull/122) ([jbalsas](https://github.com/jbalsas))-   Fixes \#72 - Make watch work by using a single WatchSocket for everything [\#121](https://github.com/liferay/liferay-js-themes-toolkit/pull/121) ([izaera](https://github.com/izaera))## [v8.0.0-rc.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.0) (2018-12-04)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.5...v8.0.0-rc.0)**Implemented enhancements:**-   Generate SourceMaps by default [\#86](https://github.com/liferay/liferay-js-themes-toolkit/issues/86)-   Dependencies warning message is missing module name [\#78](https://github.com/liferay/liferay-js-themes-toolkit/issues/78)-   Support Docker Development [\#72](https://github.com/liferay/liferay-js-themes-toolkit/issues/72)-   Add out-of-the-box support for PostCSS [\#46](https://github.com/liferay/liferay-js-themes-toolkit/issues/46)**Fixed bugs:**-   gulp theme build script does not correctly expand liferay-hook.xml language property settings [\#106](https://github.com/liferay/liferay-js-themes-toolkit/issues/106)-   gulp watch doesn't work [\#102](https://github.com/liferay/liferay-js-themes-toolkit/issues/102)-   When using gulp:watch, activate theme by default [\#93](https://github.com/liferay/liferay-js-themes-toolkit/issues/93)-   Theme generator uses Velocity syntax instead of FreeMarker for 7.1 [\#91](https://github.com/liferay/liferay-js-themes-toolkit/issues/91)-   Standard as an option in gulp kickstart [\#85](https://github.com/liferay/liferay-js-themes-toolkit/issues/85)-   liferay-theme-deps-7.1 is left when reverting 7.1 theme to 7.0 [\#77](https://github.com/liferay/liferay-js-themes-toolkit/issues/77)**Closed issues:**-   generator-liferay-theme is using event-stream 3.3.5 [\#112](https://github.com/liferay/liferay-js-themes-toolkit/issues/112)-   Deploy with gulp watch fails with NPE [\#94](https://github.com/liferay/liferay-js-themes-toolkit/issues/94)-   Fix Sourcemap support for libsass [\#81](https://github.com/liferay/liferay-js-themes-toolkit/issues/81)-   Minor typo in prompt [\#76](https://github.com/liferay/liferay-js-themes-toolkit/issues/76)-   Theme dependent on another OSGi bundle: how? [\#49](https://github.com/liferay/liferay-js-themes-toolkit/issues/49)**Merged pull requests:**-   v8.0.0-rc.1 [\#119](https://github.com/liferay/liferay-js-themes-toolkit/pull/119) ([jbalsas](https://github.com/jbalsas))-   Fixes \#72 - Show error messages [\#118](https://github.com/liferay/liferay-js-themes-toolkit/pull/118) ([jbalsas](https://github.com/jbalsas))-   Fixes \#112 - Updates packages affected by event-stream@3.3.6 to latest versions [\#117](https://github.com/liferay/liferay-js-themes-toolkit/pull/117) ([jbalsas](https://github.com/jbalsas))-   Fixes \#102 - Fix tests [\#115](https://github.com/liferay/liferay-js-themes-toolkit/pull/115) ([izaera](https://github.com/izaera))-   Fixes \#106 - Updates tests [\#109](https://github.com/liferay/liferay-js-themes-toolkit/pull/109) ([jbalsas](https://github.com/jbalsas))-   Add keyword to be found by a yeoman search [\#108](https://github.com/liferay/liferay-js-themes-toolkit/pull/108) ([marcoscv-work](https://github.com/marcoscv-work))-   Fixes \#91 - Fixes typos [\#99](https://github.com/liferay/liferay-js-themes-toolkit/pull/99) ([jbalsas](https://github.com/jbalsas))-   Fixes \#86 - Enables sourcemap generation by default [\#89](https://github.com/liferay/liferay-js-themes-toolkit/pull/89) ([jbalsas](https://github.com/jbalsas))-   Fixes \#85 - Removes Standard option from Kickstart task [\#88](https://github.com/liferay/liferay-js-themes-toolkit/pull/88) ([jbalsas](https://github.com/jbalsas))-   Fixes \#46 - Documents postcss option [\#87](https://github.com/liferay/liferay-js-themes-toolkit/pull/87) ([jbalsas](https://github.com/jbalsas))-   Fixes \#77 - Sets rubySass to false by default since node-sass should be more stable now. If necessary, a developer can always set it to true following the instructions [\#84](https://github.com/liferay/liferay-js-themes-toolkit/pull/84) ([jbalsas](https://github.com/jbalsas))-   Fixes \#78 - Display module name with warning [\#82](https://github.com/liferay/liferay-js-themes-toolkit/pull/82) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-beta.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.5) (2018-08-31)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.4...v8.0.0-beta.5)**Fixed bugs:**-   Liferay Theme Generator adds 7.0-theme-deps for new 7.1 theme [\#71](https://github.com/liferay/liferay-js-themes-toolkit/issues/71)-   Generator-Liferay-Theme: Do not insist on app server directory [\#67](https://github.com/liferay/liferay-js-themes-toolkit/issues/67)-   Generator-Liferay-Theme crashes on Node 8 [\#43](https://github.com/liferay/liferay-js-themes-toolkit/issues/43)**Merged pull requests:**-   v8.0.0-beta.5 Prepares templates [\#75](https://github.com/liferay/liferay-js-themes-toolkit/pull/75) ([jbalsas](https://github.com/jbalsas))-   Fixes \#67 - Updates liferay-plugin-node-tasks to v2.0.0 [\#74](https://github.com/liferay/liferay-js-themes-toolkit/pull/74) ([jbalsas](https://github.com/jbalsas))-   Fixes \#71 - Diverts generated theme devDependencies for 7.0 and 7.1 versions [\#73](https://github.com/liferay/liferay-js-themes-toolkit/pull/73) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-beta.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.4) (2018-08-30)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.3...v8.0.0-beta.4)**Fixed bugs:**-   Import generator fails on Gulp init task [\#64](https://github.com/liferay/liferay-js-themes-toolkit/issues/64)**Merged pull requests:**-   v8.0.0-beta.4 [\#66](https://github.com/liferay/liferay-js-themes-toolkit/pull/66) ([jbalsas](https://github.com/jbalsas))-   Fixes \#64 - Removes version check for init command [\#65](https://github.com/liferay/liferay-js-themes-toolkit/pull/65) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-beta.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.3) (2018-08-29)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.2...v8.0.0-beta.3)**Implemented enhancements:**-   Create pre-publish build step to properly update package versions [\#60](https://github.com/liferay/liferay-js-themes-toolkit/issues/60)-   Remove alloy-font-awesome import during upgrade task from a 6.2 theme [\#36](https://github.com/liferay/liferay-js-themes-toolkit/issues/36)**Fixed bugs:**-   Version reverts to 8.0.0-beta.1 after running Gulp Upgrade task for 7.0 theme [\#57](https://github.com/liferay/liferay-js-themes-toolkit/issues/57)-   Generated `liferay-theme-tasks` version is outdated for `liferay-theme:import` [\#56](https://github.com/liferay/liferay-js-themes-toolkit/issues/56)-   Remove alloy-font-awesome import during upgrade task from a 6.2 theme [\#36](https://github.com/liferay/liferay-js-themes-toolkit/issues/36)**Merged pull requests:**-   v8.0.0-beta.3 [\#63](https://github.com/liferay/liferay-js-themes-toolkit/pull/63) ([jbalsas](https://github.com/jbalsas))-   Fixes \#60 - Creates script to update package dependencies within files [\#62](https://github.com/liferay/liferay-js-themes-toolkit/pull/62) ([jbalsas](https://github.com/jbalsas))-   Fixes \#36 - Removes alloy-font-awesome imports [\#61](https://github.com/liferay/liferay-js-themes-toolkit/pull/61) ([jbalsas](https://github.com/jbalsas))-   Fixes \#57 - Updates dependencies [\#59](https://github.com/liferay/liferay-js-themes-toolkit/pull/59) ([jbalsas](https://github.com/jbalsas))-   Fixes \#56 - Updates dependency version [\#58](https://github.com/liferay/liferay-js-themes-toolkit/pull/58) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-beta.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.2) (2018-08-28)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.1...v8.0.0-beta.2)**Implemented enhancements:**-   "Upgrade" Gulp Task: Add note about Bootstrap 3's box model changes [\#51](https://github.com/liferay/liferay-js-themes-toolkit/issues/51)-   Upgrade task should warn about expected portlet_header dynamic-include extension point [\#35](https://github.com/liferay/liferay-js-themes-toolkit/issues/35)-   Improve information regarding theme/themelet npm search [\#31](https://github.com/liferay/liferay-js-themes-toolkit/issues/31)-   Setup watching of UI files outside of the standard Liferay theme directories [\#28](https://github.com/liferay/liferay-js-themes-toolkit/issues/28)**Fixed bugs:**-   Upgrade task overwrites properties in package.json with incorrect values [\#37](https://github.com/liferay/liferay-js-themes-toolkit/issues/37)-   Using gulp extend searching for themelet results in error [\#33](https://github.com/liferay/liferay-js-themes-toolkit/issues/33)-   URL in upgrade script is giving a 404 error [\#10](https://github.com/liferay/liferay-js-themes-toolkit/issues/10)**Closed issues:**-   Update liferay-theme-deps-7.0 to include latest liferay-frontend-theme-styled [\#42](https://github.com/liferay/liferay-js-themes-toolkit/issues/42)-   8.0.0-beta.1 doesn't include liferay-theme-deps-6.2 [\#38](https://github.com/liferay/liferay-js-themes-toolkit/issues/38)-   gulp extend search npm search is not finding some packages [\#25](https://github.com/liferay/liferay-js-themes-toolkit/issues/25)-   ConfigGenerator task in es2015 hook doesn't namespace modules [\#21](https://github.com/liferay/liferay-js-themes-toolkit/issues/21)-   gulp watch crashes after restart on Windows 10 [\#18](https://github.com/liferay/liferay-js-themes-toolkit/issues/18)-   Error when we search a themelet in NPM [\#17](https://github.com/liferay/liferay-js-themes-toolkit/issues/17)**Merged pull requests:**-   Prepares v8.0.0-beta.2 [\#55](https://github.com/liferay/liferay-js-themes-toolkit/pull/55) ([jbalsas](https://github.com/jbalsas))-   Fixes \#35 - Adds warning if a portlet.ftl file is found and does not contain the portlet_header extension point [\#54](https://github.com/liferay/liferay-js-themes-toolkit/pull/54) ([jbalsas](https://github.com/jbalsas))-   Fixes \#38 - Adds liferay-theme-deps-6.2 dependency to support upgrading from 6.2 with the 8.x version of the theme-tasks directly [\#53](https://github.com/liferay/liferay-js-themes-toolkit/pull/53) ([jbalsas](https://github.com/jbalsas))-   Fixes \#51 - Adds Note regarding Bootstrap3 box model change [\#52](https://github.com/liferay/liferay-js-themes-toolkit/pull/52) ([jbalsas](https://github.com/jbalsas))-   Don't overwrite rubySass setting when upgrading theme [\#41](https://github.com/liferay/liferay-js-themes-toolkit/pull/41) ([izaera](https://github.com/izaera))-   Update links to documentation and stop using deprecated Google URL shortener [\#40](https://github.com/liferay/liferay-js-themes-toolkit/pull/40) ([izaera](https://github.com/izaera))-   Setup watching of UI files outside of the standard Liferay theme directories [\#39](https://github.com/liferay/liferay-js-themes-toolkit/pull/39) ([izaera](https://github.com/izaera))-   Fix broken references to "this" [\#34](https://github.com/liferay/liferay-js-themes-toolkit/pull/34) ([izaera](https://github.com/izaera))-   Improve information regarding theme/themelet npm search [\#32](https://github.com/liferay/liferay-js-themes-toolkit/pull/32) ([izaera](https://github.com/izaera))-   SF [\#29](https://github.com/liferay/liferay-js-themes-toolkit/pull/29) ([izaera](https://github.com/izaera))-   Update package-lock.json files [\#27](https://github.com/liferay/liferay-js-themes-toolkit/pull/27) ([izaera](https://github.com/izaera))## [v8.0.0-beta.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.1) (2018-07-11)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.0...v8.0.0-beta.1)**Merged pull requests:**-   v8.0.0-beta.1 [\#23](https://github.com/liferay/liferay-js-themes-toolkit/pull/23) ([jbalsas](https://github.com/jbalsas))-   Adds namespace option to config-generator [\#22](https://github.com/liferay/liferay-js-themes-toolkit/pull/22) ([jbalsas](https://github.com/jbalsas))-   Handles inexistent npm module exception properly [\#20](https://github.com/liferay/liferay-js-themes-toolkit/pull/20) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.0) (2018-07-03)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.6...v8.0.0-beta.0)**Closed issues:**-   Deprecation support in the generator [\#15](https://github.com/liferay/liferay-js-themes-toolkit/issues/15)**Merged pull requests:**-   fix-deprecation-prompt [\#16](https://github.com/liferay/liferay-js-themes-toolkit/pull/16) ([natecavanaugh](https://github.com/natecavanaugh))## [v8.0.0-alpha.6](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.6) (2018-06-18)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.5...v8.0.0-alpha.6)## [v8.0.0-alpha.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.5) (2018-06-18)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.4...v8.0.0-alpha.5)**Fixed bugs:**-   Npm's github repository links points to old repository for the majority of the packages [\#12](https://github.com/liferay/liferay-js-themes-toolkit/issues/12)**Merged pull requests:**-   v2.0.0-beta.5 [\#14](https://github.com/liferay/liferay-js-themes-toolkit/pull/14) ([jbalsas](https://github.com/jbalsas))-   Updates repository fields in package.json files [\#13](https://github.com/liferay/liferay-js-themes-toolkit/pull/13) ([jbalsas](https://github.com/jbalsas))-   Replaces usages of gulp-util. [\#9](https://github.com/liferay/liferay-js-themes-toolkit/pull/9) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-alpha.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.4) (2018-03-23)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.3...v8.0.0-alpha.4)**Merged pull requests:**-   v8.0.0-alpha.4 [\#8](https://github.com/liferay/liferay-js-themes-toolkit/pull/8) ([jbalsas](https://github.com/jbalsas))-   Uses store url [\#7](https://github.com/liferay/liferay-js-themes-toolkit/pull/7) ([jbalsas](https://github.com/jbalsas))-   Replaces livereload with browsersync [\#6](https://github.com/liferay/liferay-js-themes-toolkit/pull/6) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-alpha.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.3) (2018-03-20)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.2...v8.0.0-alpha.3)**Merged pull requests:**-   Updates generator output dependencies [\#5](https://github.com/liferay/liferay-js-themes-toolkit/pull/5) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-alpha.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.2) (2018-03-19)[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.1...v8.0.0-alpha.2)**Merged pull requests:**-   Updates dependencies [\#4](https://github.com/liferay/liferay-js-themes-toolkit/pull/4) ([jbalsas](https://github.com/jbalsas))## [v8.0.0-alpha.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.1) (2018-03-16)**Merged pull requests:**-   Adapt tests to changes [\#3](https://github.com/liferay/liferay-js-themes-toolkit/pull/3) ([jbalsas](https://github.com/jbalsas))-   Updates lock files [\#2](https://github.com/liferay/liferay-js-themes-toolkit/pull/2) ([jbalsas](https://github.com/jbalsas))-   Makes 7.1 default and removes theme-deps-6.2 as it won't be supported in 7.1 [\#1](https://github.com/liferay/liferay-js-themes-toolkit/pull/1) ([jbalsas](https://github.com/jbalsas))
+## [v9.5.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.5.0) (2020-01-30)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.5.0-beta.0...v9.5.0)
+
+-   feat: add final theme thumbnail placeholder (#103) ([\#434](https://github.com/liferay/liferay-js-themes-toolkit/pull/434))
+-   fix: exclude .css files when extracting classic/admin theme (#432)
+    ([\#433](https://github.com/liferay/liferay-js-themes-toolkit/pull/433))
+-   docs: explain the role of PR titles in changelog generation ([\#430](https://github.com/liferay/liferay-js-themes-toolkit/pull/430))
+
+## [v9.5.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.5.0-beta.0) (2020-01-24)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.3...v9.5.0-beta.0)
+
+-   feat: support Liferay DXP 7.3 (#415), enhance R2 error reporting (#417), and provide npm scripts for gulp tasks (#381) ([\#422](https://github.com/liferay/liferay-js-themes-toolkit/pull/422))
+-   feat: support themes based on Liferay's Classic Theme (#419) ([\#425](https://github.com/liferay/liferay-js-themes-toolkit/pull/425))
+-   feat: support themes based on Liferay's Admin Theme (#423) ([\#426](https://github.com/liferay/liferay-js-themes-toolkit/pull/426))
+-   fix: extend from themelets using package URLs (#375) ([\#427](https://github.com/liferay/liferay-js-themes-toolkit/pull/427))
+-   feat: generate placeholder thumbnail.png file (#103) ([\#428](https://github.com/liferay/liferay-js-themes-toolkit/pull/428))
+
+## [v9.4.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.3) (2019-12-12)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.2...v9.4.3)
+
+-   fix: make layout generator produce correct paths on Windows (#412) ([\#413](https://github.com/liferay/liferay-js-themes-toolkit/pull/413))
+
+## [v9.4.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.2) (2019-12-11)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.1...v9.4.2)
+
+-   fix: correct misspelled function in layout generator (#409) ([\#410](https://github.com/liferay/liferay-js-themes-toolkit/pull/410))
+
+## [v9.4.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.1) (2019-11-25)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.4.0...v9.4.1)
+
+-   chore: update dependencies ([\#401](https://github.com/liferay/liferay-js-themes-toolkit/pull/401))
+-   chore: upgrade dependencies ([\#397](https://github.com/liferay/liferay-js-themes-toolkit/pull/397))
+-   chore: update eslint-config-liferay to v11.0.1 ([\#394](https://github.com/liferay/liferay-js-themes-toolkit/pull/394))
+-   chore: update eslint, eslint-config-liferay, prettier ([\#393](https://github.com/liferay/liferay-js-themes-toolkit/pull/393))
+-   chore: update dependencies ([\#391](https://github.com/liferay/liferay-js-themes-toolkit/pull/391))
+-   chore: use liferay-changelog-generator instead of scripts/changelog.js ([\#389](https://github.com/liferay/liferay-js-themes-toolkit/pull/389))
+-   feat: configure Semantic Pull Requests bot ([\#385](https://github.com/liferay/liferay-js-themes-toolkit/pull/385))
+
+## [v9.4.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.0) (2019-08-05)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.3.0...v9.4.0)
+
+-   feat: add font-awesome in upgrade process ([\#382](https://github.com/liferay/liferay-js-themes-toolkit/pull/382))
+
+## [v9.3.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.3.0) (2019-07-22)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.2.1...v9.3.0)
+
+-   feat: add support for font awesome on theme creation ([\#377](https://github.com/liferay/liferay-js-themes-toolkit/pull/377))
+
+## [v9.2.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.2.1) (2019-07-02)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.2.0...v9.2.1)
+
+-   fix: silent `npm install` failures on Windows in extend and kickstart ([\#370](https://github.com/liferay/liferay-js-themes-toolkit/pull/370))
+-   fix: Windows compatibility extending themes via URL (#365) ([\#369](https://github.com/liferay/liferay-js-themes-toolkit/pull/369))
+
+## [v9.2.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.2.0) (2019-06-27)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.5...v9.2.0)
+
+-   feat: teach `gulp extend` to accept a package URL (9.x) (#266) ([\#333](https://github.com/liferay/liferay-js-themes-toolkit/pull/333))
+
+## [v9.1.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.5) (2019-06-24)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.4...v9.1.5)
+
+-   fix: prevent proxy errors from killing the watcher ([\#358](https://github.com/liferay/liferay-js-themes-toolkit/pull/358))
+
+## [v9.1.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.4) (2019-06-11)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.3...v9.1.4)
+
+-   chore: strictly peg dependency versions (#352) ([\#353](https://github.com/liferay/liferay-js-themes-toolkit/pull/353))
+-   fix: Fix typo in JS MIME type (9.x) (#349) ([\#351](https://github.com/liferay/liferay-js-themes-toolkit/pull/351))
+
+## [v9.1.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.3) (2019-06-06)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.2...v9.1.3)
+
+-   fix(tasks): non-CSS/JS file changes break CSS when using "watch" (#340) ([\#345](https://github.com/liferay/liferay-js-themes-toolkit/pull/345))
+-   feat: add a runtime NodeJS version check (#339) ([\#343](https://github.com/liferay/liferay-js-themes-toolkit/pull/343))
+-   chore: Update theme dependencies for Liferay 7.2 release (#341) ([\#342](https://github.com/liferay/liferay-js-themes-toolkit/pull/342))
+-   chore: remove backup/revert functionality (9.x) (#267) ([\#286](https://github.com/liferay/liferay-js-themes-toolkit/pull/286))
+-   feat: handle lightweight tags in changelog script ([\#335](https://github.com/liferay/liferay-js-themes-toolkit/pull/335))
+
+## [v9.1.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.2) (2019-04-17)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.1...v9.1.2)
+
+-   perf: avoid unnecessary buffering of responses in watch mode (#324) ([\#325](https://github.com/liferay/liferay-js-themes-toolkit/pull/325))
+-   fix: invalid "this" in deploy-live:war task (9.x) ([\#322](https://github.com/liferay/liferay-js-themes-toolkit/pull/322))
+
+## [v9.1.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.1) (2019-04-12)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.1.0...v9.1.1)
+
+-   doc: add v7 to the compatibility table (9.x) (#313) ([\#317](https://github.com/liferay/liferay-js-themes-toolkit/pull/317))
+-   fix: make "watch" mode work with portal gzipped (#311) ([\#314](https://github.com/liferay/liferay-js-themes-toolkit/pull/314))
+-   fix: broken CSS and sign-in when using "watch" proxy (#309, #310) ([\#312](https://github.com/liferay/liferay-js-themes-toolkit/pull/312))
+
+## [v9.1.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.1.0) (2019-04-10)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0...v9.1.0)
+
+-   feat: teach theme tasks to accept `--sass-include-paths` option (#305) ([\#306](https://github.com/liferay/liferay-js-themes-toolkit/pull/306))
+
+## [v9.0.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0) (2019-04-09)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-beta.1...v9.0.0)
+
+-   feat: auto-deploy when starting `gulp watch` (#291) ([\#299](https://github.com/liferay/liferay-js-themes-toolkit/pull/299))
+-   fix: failure to update after non-JS/CSS changes in watch mode (#291) ([\#297](https://github.com/liferay/liferay-js-themes-toolkit/pull/297))
+
+## [v9.0.0-beta.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-beta.1) (2019-04-09)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-beta.0...v9.0.0-beta.1)
+
+-   doc: remove Gulp entry from version table (v9.x) ([\#294](https://github.com/liferay/liferay-js-themes-toolkit/pull/294))
+-   feat: add ability to config PostCSS plug-ins (9.x) (#126) ([\#289](https://github.com/liferay/liferay-js-themes-toolkit/pull/289))
+-   fix: silent failures when using autoprefixer (9.x) (#274) ([\#287](https://github.com/liferay/liferay-js-themes-toolkit/pull/287))
+
+## [v9.0.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-beta.0) (2019-04-03)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-alpha.1...v9.0.0-beta.0)
+
+-   feat: print watch info when starting watch (#277) ([\#278](https://github.com/liferay/liferay-js-themes-toolkit/pull/278))
+-   fix: make it harder to accidentally produce duplicate entries in changelog ([\#276](https://github.com/liferay/liferay-js-themes-toolkit/pull/276))
+-   feat: automatically prefetch tags before running changelog generator ([\#275](https://github.com/liferay/liferay-js-themes-toolkit/pull/275))
+-   doc: remove stale references to Visual Studio (#271) ([\#272](https://github.com/liferay/liferay-js-themes-toolkit/pull/272))
+-   feat: teach the changelog generator to correct errors with "v" prefix ([\#243](https://github.com/liferay/liferay-js-themes-toolkit/pull/243))
+-   fix: broken links in generated changelog ([\#242](https://github.com/liferay/liferay-js-themes-toolkit/pull/242))
+
+## [v9.0.0-alpha.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-alpha.1) (2019-03-21)
+
+[Full changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v9.0.0-alpha.0...v9.0.0-alpha.1)
+
+-   Create new changelog generator and use it to create 9.0.0-alpha.1 changelog ([\#239](https://github.com/liferay/liferay-js-themes-toolkit/pull/239))
+-   Make `gulp watch` pick up changes in subdirectories (v8.x) ([\#237](https://github.com/liferay/liferay-js-themes-toolkit/pull/237))
+
+## [v9.0.0-alpha.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.0.0-alpha.0) (2019-03-19)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0...v9.0.0-alpha.0)
+
+**Breaking changes:**
+
+-   Version 9 is a streamlined and modernized toolkit, focusing exclusively on generating themes, layouts and themelets for Liferay DXP and Portal CE 7.2. At the same time, we just released [version 8.0.0 of the toolkit](https://github.com/liferay/liferay-js-themes-toolkit/releases/tag/v8.0.0) that provides tools for working with Liferay DXP and Portal CE versions 7.0 and 7.1 (#184).
+
+**Other changes:**
+
+-   Themes are now generated with their dependencies explicitly listed in the "package.json" as opposed to being included transitively via a "liferay-theme-deps" package as was the case in version 8 (#168).
+
+## [v8.0.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0) (2019-03-18)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.3...v8.0.0)
+
+**Implemented enhancements:**
+
+-   Use prettier to format all eligible files, not just JS [\#151](https://github.com/liferay/liferay-js-themes-toolkit/issues/151)
+-   Migrate to Yarn [\#149](https://github.com/liferay/liferay-js-themes-toolkit/issues/149)
+-   Layouts sub-generator should generate FTL layout template file [\#129](https://github.com/liferay/liferay-js-themes-toolkit/issues/129)
+-   Make `watch` task more robust [\#127](https://github.com/liferay/liferay-js-themes-toolkit/issues/127)
+-   Cannot update packages caused by vulnerabilities for newly created theme [\#70](https://github.com/liferay/liferay-js-themes-toolkit/issues/70)
+-   Use Prettier to format all eligible files [\#153](https://github.com/liferay/liferay-js-themes-toolkit/pull/153) ([wincent](https://github.com/wincent))
+
+**Fixed bugs:**
+
+-   Remove generator dependence on globally installed gulp instance [\#172](https://github.com/liferay/liferay-js-themes-toolkit/issues/172)
+-   Imports with lexicon- prefix are not upgraded properly to 7.1 [\#143](https://github.com/liferay/liferay-js-themes-toolkit/issues/143)
+-   Erroneous update message: Update available 8.0.0-beta.1 → 8.0.0-beta.5 [\#92](https://github.com/liferay/liferay-js-themes-toolkit/issues/92)
+-   Add proper outbound licensing [\#48](https://github.com/liferay/liferay-js-themes-toolkit/issues/48)
+-   Fix post-install for layout generator [\#194](https://github.com/liferay/liferay-js-themes-toolkit/pull/194) ([wincent](https://github.com/wincent))
+-   Rename SDK reference to "toolkit" [\#186](https://github.com/liferay/liferay-js-themes-toolkit/pull/186) ([wincent](https://github.com/wincent))
+-   Overhaul normalize processing [\#178](https://github.com/liferay/liferay-js-themes-toolkit/pull/178) ([wincent](https://github.com/wincent))
+-   Remove generator dependence on globally installed gulp instance \(\#172\) [\#173](https://github.com/liferay/liferay-js-themes-toolkit/pull/173) ([wincent](https://github.com/wincent))
+
+**Closed issues:**
+
+-   Send the correct MIME type header when watching [\#208](https://github.com/liferay/liferay-js-themes-toolkit/issues/208)
+-   Retire doctor [\#196](https://github.com/liferay/liferay-js-themes-toolkit/issues/196)
+-   Fold liferay-plugin-node-tasks into liferay-theme-tasks [\#193](https://github.com/liferay/liferay-js-themes-toolkit/issues/193)
+-   Rename to liferay-js-themes-toolkit [\#185](https://github.com/liferay/liferay-js-themes-toolkit/issues/185)
+-   Clarify "compatibility matrix" between versions of liferay-js-themes-toolkit and Liferay DXP and Portal CE [\#184](https://github.com/liferay/liferay-js-themes-toolkit/issues/184)
+-   Add LICENSE.md files [\#169](https://github.com/liferay/liferay-js-themes-toolkit/issues/169)
+-   \[RFC\] Eliminate liferay-theme-deps-\* packages [\#168](https://github.com/liferay/liferay-js-themes-toolkit/issues/168)
+-   Fold liferay-theme-finder package into main SDK package [\#166](https://github.com/liferay/liferay-js-themes-toolkit/issues/166)
+-   Unwind some aspects of monorepoization [\#164](https://github.com/liferay/liferay-js-themes-toolkit/issues/164)
+-   Provide content for top-level README.md [\#154](https://github.com/liferay/liferay-js-themes-toolkit/issues/154)
+-   Drop rubySass support [\#152](https://github.com/liferay/liferay-js-themes-toolkit/issues/152)
+-   8.0.0-rc.4 [\#146](https://github.com/liferay/liferay-js-themes-toolkit/issues/146)
+-   Gulp watch doesn't work correctly when making a change on scss file [\#142](https://github.com/liferay/liferay-js-themes-toolkit/issues/142)
+-   Liferay Theme Dependencies uses a version of Lodash that is vulnerable to CVE-2018-3721 [\#141](https://github.com/liferay/liferay-js-themes-toolkit/issues/141)
+-   gulp watch with docker does not change the code [\#136](https://github.com/liferay/liferay-js-themes-toolkit/issues/136)
+-   7.1 Theme build fails due to missing import [\#128](https://github.com/liferay/liferay-js-themes-toolkit/issues/128)
+-   gulp watch fail to install theme bundle if you have liferay-hook.xml in WEB-INF [\#120](https://github.com/liferay/liferay-js-themes-toolkit/issues/120)
+-   gulp watch not taking correct version number [\#107](https://github.com/liferay/liferay-js-themes-toolkit/issues/107)
+-   make created folder name more readable from "yo liferay-theme:layout" [\#101](https://github.com/liferay/liferay-js-themes-toolkit/issues/101)
+-   Upgrade default dependencies [\#97](https://github.com/liferay/liferay-js-themes-toolkit/issues/97)
+-   gulp watch broken on Windows 10 [\#95](https://github.com/liferay/liferay-js-themes-toolkit/issues/95)
+
+**Merged pull requests:**
+
+-   Clean out packages directory [\#218](https://github.com/liferay/liferay-js-themes-toolkit/pull/218) ([wincent](https://github.com/wincent))
+-   Address some yarn audit issues \(for toolkit v9\) [\#217](https://github.com/liferay/liferay-js-themes-toolkit/pull/217) ([wincent](https://github.com/wincent))
+-   Address some yarn audit issues \(for toolkit v8\) \(\#199\) [\#216](https://github.com/liferay/liferay-js-themes-toolkit/pull/216) ([wincent](https://github.com/wincent))
+-   Remove unused "doctor" fixtures [\#215](https://github.com/liferay/liferay-js-themes-toolkit/pull/215) ([wincent](https://github.com/wincent))
+-   Fold liferay-plugin-node-tasks into liferay-theme-tasks [\#213](https://github.com/liferay/liferay-js-themes-toolkit/pull/213) ([wincent](https://github.com/wincent))
+-   Kill dead watch_socket.js and gogo-shell code \(v9\) [\#212](https://github.com/liferay/liferay-js-themes-toolkit/pull/212) ([wincent](https://github.com/wincent))
+-   Kill dead watch_socket.js and gogo-shell code [\#211](https://github.com/liferay/liferay-js-themes-toolkit/pull/211) ([wincent](https://github.com/wincent))
+-   Update template paths [\#210](https://github.com/liferay/liferay-js-themes-toolkit/pull/210) ([julien](https://github.com/julien))
+-   Send correct MIME type \(Content-Type\) header for local css files [\#209](https://github.com/liferay/liferay-js-themes-toolkit/pull/209) ([julien](https://github.com/julien))
+-   Fix "packageVersion is not defined" generator an "All" themelet [\#207](https://github.com/liferay/liferay-js-themes-toolkit/pull/207) ([wincent](https://github.com/wincent))
+-   Remove incomplete DXP and Portal CE 7.2 support from v8 of toolkit [\#206](https://github.com/liferay/liferay-js-themes-toolkit/pull/206) ([wincent](https://github.com/wincent))
+-   Add license headers to files [\#203](https://github.com/liferay/liferay-js-themes-toolkit/pull/203) ([wincent](https://github.com/wincent))
+-   Add LICENSE.md files [\#202](https://github.com/liferay/liferay-js-themes-toolkit/pull/202) ([wincent](https://github.com/wincent))
+-   Apply clean-up to new "watch" implementation [\#201](https://github.com/liferay/liferay-js-themes-toolkit/pull/201) ([julien](https://github.com/julien))
+-   Provide content for top-level README.md \(v8\) [\#200](https://github.com/liferay/liferay-js-themes-toolkit/pull/200) ([wincent](https://github.com/wincent))
+-   Update references to old repository name \(v8\) [\#197](https://github.com/liferay/liferay-js-themes-toolkit/pull/197) ([wincent](https://github.com/wincent))
+-   Update yeoman-generator v0.18.0 to 3.2.0 \(for v8 of toolkit\) [\#195](https://github.com/liferay/liferay-js-themes-toolkit/pull/195) ([wincent](https://github.com/wincent))
+-   Update yeoman-generator v0.18.0 to 3.2.0 \(for v9 of toolkit\) [\#192](https://github.com/liferay/liferay-js-themes-toolkit/pull/192) ([wincent](https://github.com/wincent))
+-   Remove nested .travis.yml file [\#191](https://github.com/liferay/liferay-js-themes-toolkit/pull/191) ([wincent](https://github.com/wincent))
+-   Make `watch` task more robust \(2nd approach\) [\#190](https://github.com/liferay/liferay-js-themes-toolkit/pull/190) ([julien](https://github.com/julien))
+-   Prepare for v8/v9 split [\#187](https://github.com/liferay/liferay-js-themes-toolkit/pull/187) ([wincent](https://github.com/wincent))
+-   Address security issues reported by "yarn audit" [\#183](https://github.com/liferay/liferay-js-themes-toolkit/pull/183) ([wincent](https://github.com/wincent))
+-   Update eslint and eslint-config-liferay to latest [\#181](https://github.com/liferay/liferay-js-themes-toolkit/pull/181) ([wincent](https://github.com/wincent))
+-   Don't use string-concatenation to build up devDependencies [\#180](https://github.com/liferay/liferay-js-themes-toolkit/pull/180) ([wincent](https://github.com/wincent))
+-   Replace the "divert\(\)" abstraction with something simpler [\#179](https://github.com/liferay/liferay-js-themes-toolkit/pull/179) ([wincent](https://github.com/wincent))
+-   Freshen lockfile [\#177](https://github.com/liferay/liferay-js-themes-toolkit/pull/177) ([wincent](https://github.com/wincent))
+-   Remove unnecessary dynamism of getDependencyName [\#176](https://github.com/liferay/liferay-js-themes-toolkit/pull/176) ([wincent](https://github.com/wincent))
+-   Remove scary warnings from normalize process in the generator [\#175](https://github.com/liferay/liferay-js-themes-toolkit/pull/175) ([wincent](https://github.com/wincent))
+-   Remove deprecated liferay-theme-finder package [\#167](https://github.com/liferay/liferay-js-themes-toolkit/pull/167) ([wincent](https://github.com/wincent))
+-   Fold "divert" into liferay-theme-tasks [\#165](https://github.com/liferay/liferay-js-themes-toolkit/pull/165) ([wincent](https://github.com/wincent))
+-   Remove \_.isPlainObject calls in divert.js \(x2\) [\#163](https://github.com/liferay/liferay-js-themes-toolkit/pull/163) ([wincent](https://github.com/wincent))
+-   Format even more files with prettier [\#162](https://github.com/liferay/liferay-js-themes-toolkit/pull/162) ([wincent](https://github.com/wincent))
+-   Update lerna, and let it know that we are using Yarn workspaces [\#160](https://github.com/liferay/liferay-js-themes-toolkit/pull/160) ([wincent](https://github.com/wincent))
+-   Remove lodash from liferay-theme-finder [\#159](https://github.com/liferay/liferay-js-themes-toolkit/pull/159) ([wincent](https://github.com/wincent))
+-   Fixes \#147 | Add support for 7.2 themes [\#158](https://github.com/liferay/liferay-js-themes-toolkit/pull/158) ([julien](https://github.com/julien))
+-   Remove update-notifier functionality [\#156](https://github.com/liferay/liferay-js-themes-toolkit/pull/156) ([wincent](https://github.com/wincent))
+-   Remove rubySass [\#155](https://github.com/liferay/liferay-js-themes-toolkit/pull/155) ([wincent](https://github.com/wincent))
+-   Migrate to Yarn [\#150](https://github.com/liferay/liferay-js-themes-toolkit/pull/150) ([wincent](https://github.com/wincent))
+-   Fixes \#128 - Imports compat/mixins to add missing BS3 mixins used in base files [\#145](https://github.com/liferay/liferay-js-themes-toolkit/pull/145) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#143 - Replaces lexicon- prefix from lexicon-base occurrences [\#144](https://github.com/liferay/liferay-js-themes-toolkit/pull/144) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-rc.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.3) (2019-02-13)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.2...v8.0.0-rc.3)
+
+**Closed issues:**
+
+-   TypeError thrown when upgrading a theme from 7.0 to 7.1 with 8.0.0-rc.2 [\#138](https://github.com/liferay/liferay-js-themes-toolkit/issues/138)
+-   Remove `ruby-sass` option from Theme Generator as it's no longer required for Windows [\#137](https://github.com/liferay/liferay-js-themes-toolkit/issues/137)
+
+**Merged pull requests:**
+
+-   Fixes \#137 - Updates theme deps versions [\#140](https://github.com/liferay/liferay-js-themes-toolkit/pull/140) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#138 - Adds bootstrap log buffer [\#139](https://github.com/liferay/liferay-js-themes-toolkit/pull/139) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-rc.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.2) (2019-01-28)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.1...v8.0.0-rc.2)
+
+**Fixed bugs:**
+
+-   Gulp upgrade changes camel-case to kebab-case only within some files [\#133](https://github.com/liferay/liferay-js-themes-toolkit/issues/133)
+-   TypeError: colors.bgblack is not a function in liferay-theme-tasks/lib/upgrade/7.0/upgrade.js:482:30\) [\#125](https://github.com/liferay/liferay-js-themes-toolkit/issues/125)
+-   gulp kickstart unable to find globally installed themes [\#100](https://github.com/liferay/liferay-js-themes-toolkit/issues/100)
+-   Building an extended theme doesn't add the parent theme files [\#11](https://github.com/liferay/liferay-js-themes-toolkit/issues/11)
+
+**Merged pull requests:**
+
+-   v.8.0.0-rc.2 [\#135](https://github.com/liferay/liferay-js-themes-toolkit/pull/135) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#133 - Updated lock files [\#134](https://github.com/liferay/liferay-js-themes-toolkit/pull/134) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#10 - SF [\#132](https://github.com/liferay/liferay-js-themes-toolkit/pull/132) ([jbalsas](https://github.com/jbalsas))
+-   Fix for the theme extension bug [\#131](https://github.com/liferay/liferay-js-themes-toolkit/pull/131) ([GianBe](https://github.com/GianBe))
+
+## [v8.0.0-rc.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.1) (2018-12-12)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-rc.0...v8.0.0-rc.1)
+
+**Fixed bugs:**
+
+-   Programatically created Bourbon file breaks sourcemap [\#83](https://github.com/liferay/liferay-js-themes-toolkit/issues/83)
+
+**Merged pull requests:**
+
+-   v8.0.0-rc.1 [\#122](https://github.com/liferay/liferay-js-themes-toolkit/pull/122) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#72 - Make watch work by using a single WatchSocket for everything [\#121](https://github.com/liferay/liferay-js-themes-toolkit/pull/121) ([izaera](https://github.com/izaera))
+
+## [v8.0.0-rc.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-rc.0) (2018-12-04)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.5...v8.0.0-rc.0)
+
+**Implemented enhancements:**
+
+-   Generate SourceMaps by default [\#86](https://github.com/liferay/liferay-js-themes-toolkit/issues/86)
+-   Dependencies warning message is missing module name [\#78](https://github.com/liferay/liferay-js-themes-toolkit/issues/78)
+-   Support Docker Development [\#72](https://github.com/liferay/liferay-js-themes-toolkit/issues/72)
+-   Add out-of-the-box support for PostCSS [\#46](https://github.com/liferay/liferay-js-themes-toolkit/issues/46)
+
+**Fixed bugs:**
+
+-   gulp theme build script does not correctly expand liferay-hook.xml language property settings [\#106](https://github.com/liferay/liferay-js-themes-toolkit/issues/106)
+-   gulp watch doesn't work [\#102](https://github.com/liferay/liferay-js-themes-toolkit/issues/102)
+-   When using gulp:watch, activate theme by default [\#93](https://github.com/liferay/liferay-js-themes-toolkit/issues/93)
+-   Theme generator uses Velocity syntax instead of FreeMarker for 7.1 [\#91](https://github.com/liferay/liferay-js-themes-toolkit/issues/91)
+-   Standard as an option in gulp kickstart [\#85](https://github.com/liferay/liferay-js-themes-toolkit/issues/85)
+-   liferay-theme-deps-7.1 is left when reverting 7.1 theme to 7.0 [\#77](https://github.com/liferay/liferay-js-themes-toolkit/issues/77)
+
+**Closed issues:**
+
+-   generator-liferay-theme is using event-stream 3.3.5 [\#112](https://github.com/liferay/liferay-js-themes-toolkit/issues/112)
+-   Deploy with gulp watch fails with NPE [\#94](https://github.com/liferay/liferay-js-themes-toolkit/issues/94)
+-   Fix Sourcemap support for libsass [\#81](https://github.com/liferay/liferay-js-themes-toolkit/issues/81)
+-   Minor typo in prompt [\#76](https://github.com/liferay/liferay-js-themes-toolkit/issues/76)
+-   Theme dependent on another OSGi bundle: how? [\#49](https://github.com/liferay/liferay-js-themes-toolkit/issues/49)
+
+**Merged pull requests:**
+
+-   v8.0.0-rc.1 [\#119](https://github.com/liferay/liferay-js-themes-toolkit/pull/119) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#72 - Show error messages [\#118](https://github.com/liferay/liferay-js-themes-toolkit/pull/118) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#112 - Updates packages affected by event-stream@3.3.6 to latest versions [\#117](https://github.com/liferay/liferay-js-themes-toolkit/pull/117) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#102 - Fix tests [\#115](https://github.com/liferay/liferay-js-themes-toolkit/pull/115) ([izaera](https://github.com/izaera))
+-   Fixes \#106 - Updates tests [\#109](https://github.com/liferay/liferay-js-themes-toolkit/pull/109) ([jbalsas](https://github.com/jbalsas))
+-   Add keyword to be found by a yeoman search [\#108](https://github.com/liferay/liferay-js-themes-toolkit/pull/108) ([marcoscv-work](https://github.com/marcoscv-work))
+-   Fixes \#91 - Fixes typos [\#99](https://github.com/liferay/liferay-js-themes-toolkit/pull/99) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#86 - Enables sourcemap generation by default [\#89](https://github.com/liferay/liferay-js-themes-toolkit/pull/89) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#85 - Removes Standard option from Kickstart task [\#88](https://github.com/liferay/liferay-js-themes-toolkit/pull/88) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#46 - Documents postcss option [\#87](https://github.com/liferay/liferay-js-themes-toolkit/pull/87) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#77 - Sets rubySass to false by default since node-sass should be more stable now. If necessary, a developer can always set it to true following the instructions [\#84](https://github.com/liferay/liferay-js-themes-toolkit/pull/84) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#78 - Display module name with warning [\#82](https://github.com/liferay/liferay-js-themes-toolkit/pull/82) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.5) (2018-08-31)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.4...v8.0.0-beta.5)
+
+**Fixed bugs:**
+
+-   Liferay Theme Generator adds 7.0-theme-deps for new 7.1 theme [\#71](https://github.com/liferay/liferay-js-themes-toolkit/issues/71)
+-   Generator-Liferay-Theme: Do not insist on app server directory [\#67](https://github.com/liferay/liferay-js-themes-toolkit/issues/67)
+-   Generator-Liferay-Theme crashes on Node 8 [\#43](https://github.com/liferay/liferay-js-themes-toolkit/issues/43)
+
+**Merged pull requests:**
+
+-   v8.0.0-beta.5 Prepares templates [\#75](https://github.com/liferay/liferay-js-themes-toolkit/pull/75) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#67 - Updates liferay-plugin-node-tasks to v2.0.0 [\#74](https://github.com/liferay/liferay-js-themes-toolkit/pull/74) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#71 - Diverts generated theme devDependencies for 7.0 and 7.1 versions [\#73](https://github.com/liferay/liferay-js-themes-toolkit/pull/73) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.4) (2018-08-30)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.3...v8.0.0-beta.4)
+
+**Fixed bugs:**
+
+-   Import generator fails on Gulp init task [\#64](https://github.com/liferay/liferay-js-themes-toolkit/issues/64)
+
+**Merged pull requests:**
+
+-   v8.0.0-beta.4 [\#66](https://github.com/liferay/liferay-js-themes-toolkit/pull/66) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#64 - Removes version check for init command [\#65](https://github.com/liferay/liferay-js-themes-toolkit/pull/65) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.3) (2018-08-29)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.2...v8.0.0-beta.3)
+
+**Implemented enhancements:**
+
+-   Create pre-publish build step to properly update package versions [\#60](https://github.com/liferay/liferay-js-themes-toolkit/issues/60)
+-   Remove alloy-font-awesome import during upgrade task from a 6.2 theme [\#36](https://github.com/liferay/liferay-js-themes-toolkit/issues/36)
+
+**Fixed bugs:**
+
+-   Version reverts to 8.0.0-beta.1 after running Gulp Upgrade task for 7.0 theme [\#57](https://github.com/liferay/liferay-js-themes-toolkit/issues/57)
+-   Generated `liferay-theme-tasks` version is outdated for `liferay-theme:import` [\#56](https://github.com/liferay/liferay-js-themes-toolkit/issues/56)
+-   Remove alloy-font-awesome import during upgrade task from a 6.2 theme [\#36](https://github.com/liferay/liferay-js-themes-toolkit/issues/36)
+
+**Merged pull requests:**
+
+-   v8.0.0-beta.3 [\#63](https://github.com/liferay/liferay-js-themes-toolkit/pull/63) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#60 - Creates script to update package dependencies within files [\#62](https://github.com/liferay/liferay-js-themes-toolkit/pull/62) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#36 - Removes alloy-font-awesome imports [\#61](https://github.com/liferay/liferay-js-themes-toolkit/pull/61) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#57 - Updates dependencies [\#59](https://github.com/liferay/liferay-js-themes-toolkit/pull/59) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#56 - Updates dependency version [\#58](https://github.com/liferay/liferay-js-themes-toolkit/pull/58) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.2) (2018-08-28)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.1...v8.0.0-beta.2)
+
+**Implemented enhancements:**
+
+-   "Upgrade" Gulp Task: Add note about Bootstrap 3's box model changes [\#51](https://github.com/liferay/liferay-js-themes-toolkit/issues/51)
+-   Upgrade task should warn about expected portlet_header dynamic-include extension point [\#35](https://github.com/liferay/liferay-js-themes-toolkit/issues/35)
+-   Improve information regarding theme/themelet npm search [\#31](https://github.com/liferay/liferay-js-themes-toolkit/issues/31)
+-   Setup watching of UI files outside of the standard Liferay theme directories [\#28](https://github.com/liferay/liferay-js-themes-toolkit/issues/28)
+
+**Fixed bugs:**
+
+-   Upgrade task overwrites properties in package.json with incorrect values [\#37](https://github.com/liferay/liferay-js-themes-toolkit/issues/37)
+-   Using gulp extend searching for themelet results in error [\#33](https://github.com/liferay/liferay-js-themes-toolkit/issues/33)
+-   URL in upgrade script is giving a 404 error [\#10](https://github.com/liferay/liferay-js-themes-toolkit/issues/10)
+
+**Closed issues:**
+
+-   Update liferay-theme-deps-7.0 to include latest liferay-frontend-theme-styled [\#42](https://github.com/liferay/liferay-js-themes-toolkit/issues/42)
+-   8.0.0-beta.1 doesn't include liferay-theme-deps-6.2 [\#38](https://github.com/liferay/liferay-js-themes-toolkit/issues/38)
+-   gulp extend search npm search is not finding some packages [\#25](https://github.com/liferay/liferay-js-themes-toolkit/issues/25)
+-   ConfigGenerator task in es2015 hook doesn't namespace modules [\#21](https://github.com/liferay/liferay-js-themes-toolkit/issues/21)
+-   gulp watch crashes after restart on Windows 10 [\#18](https://github.com/liferay/liferay-js-themes-toolkit/issues/18)
+-   Error when we search a themelet in NPM [\#17](https://github.com/liferay/liferay-js-themes-toolkit/issues/17)
+
+**Merged pull requests:**
+
+-   Prepares v8.0.0-beta.2 [\#55](https://github.com/liferay/liferay-js-themes-toolkit/pull/55) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#35 - Adds warning if a portlet.ftl file is found and does not contain the portlet_header extension point [\#54](https://github.com/liferay/liferay-js-themes-toolkit/pull/54) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#38 - Adds liferay-theme-deps-6.2 dependency to support upgrading from 6.2 with the 8.x version of the theme-tasks directly [\#53](https://github.com/liferay/liferay-js-themes-toolkit/pull/53) ([jbalsas](https://github.com/jbalsas))
+-   Fixes \#51 - Adds Note regarding Bootstrap3 box model change [\#52](https://github.com/liferay/liferay-js-themes-toolkit/pull/52) ([jbalsas](https://github.com/jbalsas))
+-   Don't overwrite rubySass setting when upgrading theme [\#41](https://github.com/liferay/liferay-js-themes-toolkit/pull/41) ([izaera](https://github.com/izaera))
+-   Update links to documentation and stop using deprecated Google URL shortener [\#40](https://github.com/liferay/liferay-js-themes-toolkit/pull/40) ([izaera](https://github.com/izaera))
+-   Setup watching of UI files outside of the standard Liferay theme directories [\#39](https://github.com/liferay/liferay-js-themes-toolkit/pull/39) ([izaera](https://github.com/izaera))
+-   Fix broken references to "this" [\#34](https://github.com/liferay/liferay-js-themes-toolkit/pull/34) ([izaera](https://github.com/izaera))
+-   Improve information regarding theme/themelet npm search [\#32](https://github.com/liferay/liferay-js-themes-toolkit/pull/32) ([izaera](https://github.com/izaera))
+-   SF [\#29](https://github.com/liferay/liferay-js-themes-toolkit/pull/29) ([izaera](https://github.com/izaera))
+-   Update package-lock.json files [\#27](https://github.com/liferay/liferay-js-themes-toolkit/pull/27) ([izaera](https://github.com/izaera))
+
+## [v8.0.0-beta.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.1) (2018-07-11)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-beta.0...v8.0.0-beta.1)
+
+**Merged pull requests:**
+
+-   v8.0.0-beta.1 [\#23](https://github.com/liferay/liferay-js-themes-toolkit/pull/23) ([jbalsas](https://github.com/jbalsas))
+-   Adds namespace option to config-generator [\#22](https://github.com/liferay/liferay-js-themes-toolkit/pull/22) ([jbalsas](https://github.com/jbalsas))
+-   Handles inexistent npm module exception properly [\#20](https://github.com/liferay/liferay-js-themes-toolkit/pull/20) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.0](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-beta.0) (2018-07-03)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.6...v8.0.0-beta.0)
+
+**Closed issues:**
+
+-   Deprecation support in the generator [\#15](https://github.com/liferay/liferay-js-themes-toolkit/issues/15)
+
+**Merged pull requests:**
+
+-   fix-deprecation-prompt [\#16](https://github.com/liferay/liferay-js-themes-toolkit/pull/16) ([natecavanaugh](https://github.com/natecavanaugh))
+
+## [v8.0.0-alpha.6](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.6) (2018-06-18)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.5...v8.0.0-alpha.6)
+
+## [v8.0.0-alpha.5](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.5) (2018-06-18)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.4...v8.0.0-alpha.5)
+
+**Fixed bugs:**
+
+-   Npm's github repository links points to old repository for the majority of the packages [\#12](https://github.com/liferay/liferay-js-themes-toolkit/issues/12)
+
+**Merged pull requests:**
+
+-   v2.0.0-beta.5 [\#14](https://github.com/liferay/liferay-js-themes-toolkit/pull/14) ([jbalsas](https://github.com/jbalsas))
+-   Updates repository fields in package.json files [\#13](https://github.com/liferay/liferay-js-themes-toolkit/pull/13) ([jbalsas](https://github.com/jbalsas))
+-   Replaces usages of gulp-util. [\#9](https://github.com/liferay/liferay-js-themes-toolkit/pull/9) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-alpha.4](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.4) (2018-03-23)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.3...v8.0.0-alpha.4)
+
+**Merged pull requests:**
+
+-   v8.0.0-alpha.4 [\#8](https://github.com/liferay/liferay-js-themes-toolkit/pull/8) ([jbalsas](https://github.com/jbalsas))
+-   Uses store url [\#7](https://github.com/liferay/liferay-js-themes-toolkit/pull/7) ([jbalsas](https://github.com/jbalsas))
+-   Replaces livereload with browsersync [\#6](https://github.com/liferay/liferay-js-themes-toolkit/pull/6) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-alpha.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.3) (2018-03-20)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.2...v8.0.0-alpha.3)
+
+**Merged pull requests:**
+
+-   Updates generator output dependencies [\#5](https://github.com/liferay/liferay-js-themes-toolkit/pull/5) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-alpha.2](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.2) (2018-03-19)
+
+[Full Changelog](https://github.com/liferay/liferay-js-themes-toolkit/compare/v8.0.0-alpha.1...v8.0.0-alpha.2)
+
+**Merged pull requests:**
+
+-   Updates dependencies [\#4](https://github.com/liferay/liferay-js-themes-toolkit/pull/4) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-alpha.1](https://github.com/liferay/liferay-js-themes-toolkit/tree/v8.0.0-alpha.1) (2018-03-16)
+
+**Merged pull requests:**
+
+-   Adapt tests to changes [\#3](https://github.com/liferay/liferay-js-themes-toolkit/pull/3) ([jbalsas](https://github.com/jbalsas))
+-   Updates lock files [\#2](https://github.com/liferay/liferay-js-themes-toolkit/pull/2) ([jbalsas](https://github.com/jbalsas))
+-   Makes 7.1 default and removes theme-deps-6.2 as it won't be supported in 7.1 [\#1](https://github.com/liferay/liferay-js-themes-toolkit/pull/1) ([jbalsas](https://github.com/jbalsas))


### PR DESCRIPTION
Somehow, in 322efe3d55ad43dd417f441095ccb4f15dc1c884, all newlines got converted to carriage returns. Tools such as Git consider such line endings to be invalid: see how GitHub renders the entire file on a single line in "Blame" view.

![liferay-js-themes-toolkit_CHANGELOG_md_at_master_·_liferay_liferay-js-themes-toolkit](https://user-images.githubusercontent.com/7074/74662681-aa2b4f80-519a-11ea-8024-29318831757e.png)

I doubt that the changelog generator did this, because [it uses newlines](https://github.com/liferay/liferay-npm-tools/blob/19cddf8eb8d736c0bad5eb9ab8bddfb4423865f8/packages/liferay-changelog-generator/src/index.js#L207
).

Probably just a misconfigured editor or some other tool.

Note line count before (0), fix using `tr`, and line count after (501):

    wc CHANGELOG.md
          0    2528   41440 CHANGELOG.md
    cat CHANGELOG.md | tr '\r' '\n' > tmp.md
    mv tmp.md CHANGELOG.md
    wc CHANGELOG.md
        501    2528   41440 CHANGELOG.md