### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /**/node_modules/*
+/copyright.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+# MIT License
+
+Copyright (c) 2017 Liferay, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/jest.js
+++ b/jest.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/admin/admin.js
+++ b/packages/generator-liferay-theme/generators/admin/admin.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/admin/index.js
+++ b/packages/generator-liferay-theme/generators/admin/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/app/app.js
+++ b/packages/generator-liferay-theme/generators/app/app.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/classic/classic.js
+++ b/packages/generator-liferay-theme/generators/classic/classic.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/classic/index.js
+++ b/packages/generator-liferay-theme/generators/classic/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/facet-theme/index.js
+++ b/packages/generator-liferay-theme/generators/facet-theme/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/layout/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/layout/standalone-layout.js
+++ b/packages/generator-liferay-theme/generators/layout/standalone-layout.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/layout/theme-layout.js
+++ b/packages/generator-liferay-theme/generators/layout/theme-layout.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/generators/themelet/index.js
+++ b/packages/generator-liferay-theme/generators/themelet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/gulpfile.js
+++ b/packages/generator-liferay-theme/gulpfile.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/Copier.js
+++ b/packages/generator-liferay-theme/lib/Copier.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/LayoutCreator.js
+++ b/packages/generator-liferay-theme/lib/LayoutCreator.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/ProgressLine.js
+++ b/packages/generator-liferay-theme/lib/ProgressLine.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/Project.js
+++ b/packages/generator-liferay-theme/lib/Project.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/__tests__/LayoutCreator.test.js
+++ b/packages/generator-liferay-theme/lib/__tests__/LayoutCreator.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/generation/layout.js
+++ b/packages/generator-liferay-theme/lib/generation/layout.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/generation/theme-based.js
+++ b/packages/generator-liferay-theme/lib/generation/theme-based.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/util.js
+++ b/packages/generator-liferay-theme/lib/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/generator-liferay-theme/lib/versions.js
+++ b/packages/generator-liferay-theme/lib/versions.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/index.js
+++ b/packages/liferay-theme-tasks/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/look_and_feel_util.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/options.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/options.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/status.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/status.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/theme_finder.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/theme_finder.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/util.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/util.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/__tests__/war_deployer.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/war_deployer.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
+++ b/packages/liferay-theme-tasks/lib/bourbon_dependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/checkNodeVersion.js
+++ b/packages/liferay-theme-tasks/lib/checkNodeVersion.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/getBaseThemeDependencies.js
+++ b/packages/liferay-theme-tasks/lib/getBaseThemeDependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/liferay_theme_config.js
+++ b/packages/liferay-theme-tasks/lib/liferay_theme_config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/look_and_feel_util.js
+++ b/packages/liferay-theme-tasks/lib/look_and_feel_util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/normalize.js
+++ b/packages/liferay-theme-tasks/lib/normalize.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/options.js
+++ b/packages/liferay-theme-tasks/lib/options.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/global_module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/global_module_prompt.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/kickstart_prompt.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/module_prompt.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/npm_module_prompt.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/prompt_util.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/global_module_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/kickstart_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/module_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/npm_module_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
+++ b/packages/liferay-theme-tasks/lib/prompts/prompt_util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/url_package_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/index.js
+++ b/packages/liferay-theme-tasks/lib/r2/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/css-parse.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/bg.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/fontawesome.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
+++ b/packages/liferay-theme-tasks/lib/r2/liferay-r2/plugins/yui3.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/status.js
+++ b/packages/liferay-theme-tasks/lib/status.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/theme_inspector.js
+++ b/packages/liferay-theme-tasks/lib/theme_inspector.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.1/upgrade.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/upgrade/7.2/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.2/upgrade.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/util.js
+++ b/packages/liferay-theme-tasks/lib/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/lib/war_deployer.js
+++ b/packages/liferay-theme-tasks/lib/war_deployer.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/index.js
+++ b/packages/liferay-theme-tasks/plugin/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/lib/init_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/lib/options.js
+++ b/packages/liferay-theme-tasks/plugin/lib/options.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/lib/register_hooks.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/deploy.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/tasks/index.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/init.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/version.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/tasks/war.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-1.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-2.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-3.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-3.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-4.js
+++ b/packages/liferay-theme-tasks/plugin/test/fixtures/hook_modules/hook-module-4.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/index.js
+++ b/packages/liferay-theme-tasks/plugin/test/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/init_prompt.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
+++ b/packages/liferay-theme-tasks/plugin/test/lib/register_hooks.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/deploy.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/init.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/init.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/version.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/version.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/plugin/test/tasks/war.js
+++ b/packages/liferay-theme-tasks/plugin/test/tasks/war.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/deploy.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/kickstart.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/status.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/build/themelets.js
+++ b/packages/liferay-theme-tasks/tasks/build/themelets.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/tasks/deploy.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/extend.js
+++ b/packages/liferay-theme-tasks/tasks/extend.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/init.js
+++ b/packages/liferay-theme-tasks/tasks/init.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/kickstart.js
+++ b/packages/liferay-theme-tasks/tasks/kickstart.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/overwrite.js
+++ b/packages/liferay-theme-tasks/tasks/overwrite.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/status.js
+++ b/packages/liferay-theme-tasks/tasks/status.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/upgrade.js
+++ b/packages/liferay-theme-tasks/tasks/upgrade.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/tasks/watch.js
+++ b/packages/liferay-theme-tasks/tasks/watch.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.1/base-theme/src/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.1/base-theme/src/js/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.1/explicit-dependency-theme/custom_src_path/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.1/explicit-dependency-theme/custom_src_path/js/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.1/kickstart-theme/src/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.1/kickstart-theme/src/js/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.2/base-theme-7-2/src/js/main.js
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.2/base-theme-7-2/src/js/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/qa.js
+++ b/scripts/qa.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/update-package-versions-config.js
+++ b/update-package-versions-config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 


### PR DESCRIPTION
This change is analogous to the one I just made in:

- https://github.com/liferay/eslint-config-liferay/pull/151
- https://github.com/liferay/liferay-npm-tools/pull/394

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js`, preserving the original year, running `yarn lint:fix`, and then applying manual fixes in the `bin` files (because of its use of "shebang" line, the linter adds a redundant copy of the header). I used a Vim macro to strip out the original headers. Finally, I changed the hardcoded year in the copyright.js template (2017) to a `<%= YEAR %>`, so that subsequently created files will use the current year.

Adds a copy of the license to `LICENSES/MIT.txt`.