### PR TITLE
docs: fix bad Markdown syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### :package: Miscellaneous
 
--   Merging to continue with (milestone)[https://github.com/liferay/liferay-js-themes-toolkit/milestone/11] development. ([\#422](https://github.com/liferay/liferay-js-themes-toolkit/pull/422))
+-   Merging to continue with [milestone](https://github.com/liferay/liferay-js-themes-toolkit/milestone/11) development. ([\#422](https://github.com/liferay/liferay-js-themes-toolkit/pull/422))
 
 ## [v9.4.3](https://github.com/liferay/liferay-js-themes-toolkit/tree/v9.4.3) (2019-12-12)
 


### PR DESCRIPTION
This Markdown was extracted from the commit message in a2bd807b8031ed6, but we can fix it manually; seeing as we won't be regenerating the changelog but rather will be appending from now on, we can expect the fix to be preserved.

Just a reminder to anybody that sees this, in order to keep the changelog quality high and free from errors like this, we should be accepting the proposed merge commit generated by GitHub when we merge in PRs and avoid hand-editing.