### PR TITLE
chore: Add release-snapshot script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
 		"chalk": "^3.0.0",
 		"eslint": "^6.5.1",
 		"eslint-config-liferay": "^13.0.0",
+		"execa": "^4.0.0",
 		"fs-extra": "^8.1.0",
 		"jest": "^24.1.0",
 		"prettier": "^1.18.2",
+		"readline-sync": "^1.4.10",
 		"yargs": "^15.1.0"
 	},
 	"private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"devDependencies": {
+		"chalk": "^3.0.0",
 		"eslint": "^6.5.1",
 		"eslint-config-liferay": "^13.0.0",
 		"fs-extra": "^8.1.0",

--- a/packages/generator-liferay-theme/package.json
+++ b/packages/generator-liferay-theme/package.json
@@ -55,5 +55,8 @@
 		"gulp-coveralls": "^0.1.4",
 		"sinon": "^4.4.6",
 		"strip-ansi": "^3.0.1"
+	},
+	"scripts": {
+		"release:snapshot": "node ../../scripts/release-snapshot.js"
 	}
 }

--- a/packages/liferay-theme-mixins/package.json
+++ b/packages/liferay-theme-mixins/package.json
@@ -23,5 +23,8 @@
 		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-mixins"
 	},
+	"scripts": {
+		"release:snapshot": "node ../../scripts/release-snapshot.js"
+	},
 	"version": "9.5.0"
 }

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -66,5 +66,8 @@
 		"url": "https://github.com/liferay/liferay-js-themes-toolkit",
 		"directory": "packages/liferay-theme-tasks"
 	},
+	"scripts": {
+		"release:snapshot": "node ../../scripts/release-snapshot.js"
+	},
 	"version": "9.5.0"
 }

--- a/scripts/release-snapshot.js
+++ b/scripts/release-snapshot.js
@@ -12,7 +12,6 @@ const readlineSync = require('readline-sync');
 const {abort, success, warn} = require('./util/report');
 const {git, yarn} = require('./util/run');
 
-const EXPECTED_PREPUBLISH = 'node ../../scripts/disable-publish.js';
 const RAW_PKG_JSON = fs.readFileSync('package.json');
 const PKG_JSON = JSON.parse(RAW_PKG_JSON);
 const RELEASE_BRANCH = ['master'];
@@ -101,14 +100,6 @@ async function main() {
 		...PKG_JSON,
 		version: `${PKG_JSON.version}-snapshot.${commitHash}`,
 	};
-
-	if (pkgJson.scripts.prepublish !== EXPECTED_PREPUBLISH) {
-		throw `Prepublish script incorrectly configured: please set it to '${EXPECTED_PREPUBLISH}'`;
-	}
-
-	delete pkgJson.scripts.prepublish;
-
-	fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, '\t'));
 
 	await yarn.pipe('publish', '--tag', 'snapshot', '--non-interactive');
 

--- a/scripts/release-snapshot.js
+++ b/scripts/release-snapshot.js
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/* eslint-disable no-console */
+
+const fs = require('fs-extra');
+const path = require('path');
+const readlineSync = require('readline-sync');
+
+const {abort, success, warn} = require('./util/report');
+const {git, yarn} = require('./util/run');
+
+const EXPECTED_PREPUBLISH = 'node ../../scripts/disable-publish.js';
+const RAW_PKG_JSON = fs.readFileSync('package.json');
+const PKG_JSON = JSON.parse(RAW_PKG_JSON);
+const RELEASE_BRANCH = ['master'];
+const WORKSPACE_DIR = path.resolve(path.join(__dirname, '..'));
+
+async function isStatusClean(status) {
+	if (status === '') {
+		return true;
+	}
+
+	const lines = status.split('\n');
+
+	if (lines.length > 1) {
+		return false;
+	}
+
+	if (lines[0] !== ` M packages/${PKG_JSON.name}/package.json`) {
+		return false;
+	}
+
+	console.log('');
+	warn('File package.json is modified');
+
+	console.log('');
+	await git.pipe('diff', 'package.json');
+	console.log('');
+
+	const answer = readlineSync.question('Do you want to continue (y/N)? ');
+
+	if (answer !== 'y') {
+		return false;
+	}
+
+	return true;
+}
+
+async function main() {
+	const status = await git('status', '--porcelain');
+
+	if (!(await isStatusClean(status))) {
+		throw 'Working copy has local changes';
+	}
+
+	success('Working copy is clean');
+
+	const branch = await git('rev-parse', '--abbrev-ref', 'HEAD');
+
+	if (branch != RELEASE_BRANCH) {
+		throw `Only releases from branch ${RELEASE_BRANCH} allowed`;
+	}
+
+	success('Branch name is OK');
+
+	try {
+		await git('pull', '--ff-only', 'upstream', branch);
+	} catch (err) {
+		console.error(err.message);
+		throw `Cannot FF pull from upstream/${branch}: please check your local branch status`;
+	}
+
+	success(`Branch upstream/${branch} pulled correctly`);
+
+	const commitHash = await git('rev-parse', '--short', 'HEAD');
+	const upstreamHash = await git(
+		'rev-parse',
+		'--short',
+		`upstream/${branch}`
+	);
+
+	if (upstreamHash !== commitHash) {
+		throw 'Local branch is ahead of upstream';
+	}
+
+	success('Upstream and local branches are in sync');
+
+	try {
+		await yarn.pipe('ci', {cwd: WORKSPACE_DIR});
+	} catch (err) {
+		console.error(err.message);
+		throw `CI checks failed: please fix and try again`;
+	}
+
+	success('CI tests passed');
+
+	const pkgJson = {
+		...PKG_JSON,
+		version: `${PKG_JSON.version}-snapshot.${commitHash}`,
+	};
+
+	if (pkgJson.scripts.prepublish !== EXPECTED_PREPUBLISH) {
+		throw `Prepublish script incorrectly configured: please set it to '${EXPECTED_PREPUBLISH}'`;
+	}
+
+	delete pkgJson.scripts.prepublish;
+
+	fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, '\t'));
+
+	await yarn.pipe('publish', '--tag', 'snapshot', '--non-interactive');
+
+	success(
+		`Published version ${pkgJson.version} to https://www.npmjs.com/package/${pkgJson.name}`
+	);
+}
+
+main()
+	.then(() => fs.writeFileSync('package.json', RAW_PKG_JSON))
+	.catch(err => {
+		fs.writeFileSync('package.json', RAW_PKG_JSON);
+
+		if (typeof err === 'string') {
+			abort(err);
+		} else {
+			console.error(err);
+			process.exit(1);
+		}
+	});

--- a/scripts/util/report.js
+++ b/scripts/util/report.js
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/* eslint-disable no-console */
+
+const {green, red, yellow} = require('chalk');
+
+function abort(...msgs) {
+	console.error('');
+	console.error(red('❌', msgs.join('\n')));
+	console.error('');
+
+	process.exit(1);
+}
+
+function success(...msgs) {
+	console.log(green('✔️', msgs.join('\n')));
+}
+
+function warn(...msgs) {
+	console.error(yellow('⚠️', msgs.join('\n')));
+}
+
+module.exports = {
+	abort,
+	success,
+	warn,
+};

--- a/scripts/util/run.js
+++ b/scripts/util/run.js
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const execa = require('execa');
+
+async function run(cmd, ...args) {
+	let opts = {};
+
+	if (typeof args[args.length - 1] === 'object') {
+		opts = args.pop();
+	}
+
+	const {stderr, stdout} = await execa(cmd, args, opts);
+
+	stdout.stderr = stderr;
+
+	return stdout;
+}
+
+run.pipe = async (cmd, ...args) => {
+	let opts = {};
+
+	if (typeof args[args.length - 1] === 'object') {
+		opts = args.pop();
+	}
+
+	const promise = execa(cmd, args, opts);
+
+	promise.stdout.pipe(process.stdout);
+
+	const {stderr, stdout} = await promise;
+
+	stdout.stderr = stderr;
+
+	return stdout;
+};
+
+const git = async (...args) => await run('git', ...args);
+git.pipe = async (...args) => await run.pipe('git', ...args);
+
+const runNodeBin = async (bin, ...args) =>
+	await run(bin, ...args, {preferLocal: true});
+runNodeBin.pipe = async (bin, ...args) =>
+	await run.pipe(bin, ...args, {preferLocal: true});
+
+const yarn = async (...args) => await run('yarn', ...args);
+yarn.pipe = async (...args) => await run.pipe('yarn', ...args);
+
+module.exports = {
+	git,
+	run,
+	runNodeBin,
+	yarn,
+};

--- a/update-package-versions-config.js
+++ b/update-package-versions-config.js
@@ -3,17 +3,21 @@
  * SPDX-License-Identifier: MIT
  */
 
+const {red} = require('chalk');
+
 const version = process.argv[3];
 
-let FIXTURE;
+if (version === undefined) {
+	console.error(
+		red(`
+❌ Please specify version number as an argument to the script
+`)
+	);
+	process.exit(1);
+}
 
 module.exports = {
-	files: [
-		'packages/*/package.json',
-		'packages/liferay-theme-tasks/lib/**/*',
-		(FIXTURE =
-			'packages/liferay-theme-tasks/test/fixtures/themes/7.2/base-theme-7-2/package.json'),
-	],
+	files: ['packages/*/package.json'],
 	from: [
 		/"liferay-theme-tasks": ".*"/g,
 		/'liferay-theme-tasks': '.*'/g,
@@ -22,16 +26,6 @@ module.exports = {
 	to: [
 		`"liferay-theme-tasks": "^${version}"`,
 		`'liferay-theme-tasks': '^${version}'`,
-		(match, ...rest) => {
-			const filename = rest[rest.length - 1];
-
-			// Some nasty special-casing for the FIXTURE, which has multiple
-			// "version" strings inside it that we don't want to mess with.
-			if (filename === FIXTURE) {
-				return match;
-			}
-
-			return `"version": "${version}"`;
-		},
+		() => `"version": "${version}"`,
 	],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,6 +1852,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -2508,6 +2517,21 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -3780,6 +3804,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4251,6 +4280,11 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-string@^1.0.5:
   version "1.0.5"
@@ -5814,6 +5848,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -6210,6 +6251,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -6653,6 +6699,11 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 readline2@^1.0.1:
   version "1.0.1"
@@ -7172,10 +7223,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shelljs@^0.8.0:
   version "0.8.3"
@@ -7608,6 +7671,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -8326,6 +8394,13 @@ which@1, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
I'm copying the release-snapshot script from JS Toolkit to be able to automate snapshot releases and make the process less error prone.