### PR TITLE
docs: mention versions > v9 in the compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 | Capability                      | Required toolkit version |
 | ------------------------------- | ------------------------ |
 | Create themes for 6.2           | v7.x                     |
+|                                 |                          |
 | Import a 6.2 theme              | v8.x                     |
 | Create themes for 7.0           | v8.x                     |
 | Create themes for 7.1           | v8.x                     |
 | Upgrade a theme for 6.2 to 7.0  | v8.x                     |
 | Upgrade a theme for 7.0 to 7.1  | v8.x                     |
-| Upgrade a theme for 7.1 to 7.2  | v9.x                     |
-| Upgrade a theme for 7.2 to 7.3  | v9.x                     |
-| Create themes for 7.2 and above | v9.x                     |
+|                                 |                          |
+| Upgrade a theme for 7.1 to 7.2  | v9.x or above            |
+| Upgrade a theme for 7.2 to 7.3  | v9.x or above            |
+| Create themes for 7.2 and above | v9.x or above            |

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Other differences between the major versions:
 Notes:
 
 -   The 7.x series of the toolkit is unlikely to receive any further development, so is effectively deprecated.
--   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 or v9 in order to avoid the breaking changes involved in moving to v10 (specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).
+-   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 (because you need to target DXP 7.0 or 7.1) or v9 (because you want to avoid the breaking changes involved in updating to v10; specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).

--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ Starting with version 9 of the toolkit, in order to keep the toolkit simple, eac
 | Upgrade a theme for 7.1 to 7.2  | v9.x or above            |
 | Upgrade a theme for 7.2 to 7.3  | v9.x or above            |
 | Create themes for 7.2 and above | v9.x or above            |
+
+Other differences between the major versions:
+
+| Toolkit version | Branch   | Status             |
+| --------------- | -------- | ------------------ |
+| 7.x             | -        | deprecated         |
+| 8.x             | `8.x`    | maintenance        |
+| 9.x             | `9.x`    | maintenance        |
+| 10.x            | `master` | active development |
+
+Notes:
+
+-   The 7.x series of the toolkit is unlikely to receive any further development, so is effectively deprecated.
+-   Most active development is taking place on the `master` branch, corresponding to the 10.x series of releases, but the 8.x and 9.x series are still valid for existing themes. You may wish to continue using v8 or v9 in order to avoid the breaking changes involved in moving to v10 (specifically, moving from Gulp v3 to Gulp v4, which may require custom theme tasks to be updated).


### PR DESCRIPTION
Added blank lines as well to make the different versions more obvious.

Not currently mentioning that we're going to "deprecate" v9 as there is no great urgency for people to move off it (unless they want to use Node v12), but at some point we should mention that.