### PR TITLE
feat: automatically tag 8.x releases with "maintenance" tag

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--publish.tag maintenance


### PR DESCRIPTION
As described [here](https://github.com/liferay/liferay-js-themes-toolkit/issues/473#issuecomment-614038031), this change, together with the corresponding PR to the 9.x branch, will ensure that only non-prerelease `master` (ie. v10) release get the "latest" tag on NPM.