### PR TITLE
docs: update CONTRIBUTING.md

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--version.preid pre

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ yarn format
 
 ## JS Docs
 
-All methods should be documented, following [google's format](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler).
+All methods should be documented, following [Google's format](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler).
 
 # Releasing
 
@@ -69,13 +69,13 @@ Obviously, depending on how version constraints for `liferay-theme-tasks` are wr
 
 ### 3. Update CHANGELOG.md
 
-Run this in the project's folder so that `CHANGELOG.md` is updated:
+For any given package that you are going to release, run this in the package's folder:
 
 ```sh
-yarn changelog --version=project-name/v1.2.3
+yarn changelog --version=v1.2.3
 ```
 
-Changing `project-name` and `1.2.3` by the proper values.
+Changing `v1.2.3` to the proper value. The format for normal releases is `v1.2.3` and the format for prereleases is `v1.2.3-pre.0` (followed by `v1.2.3-pre.1`, `v1.2.3-pre.2` etc).
 
 Then, review `CHANGELOG.md`, change anything that needs to be adjusted and save it.
 
@@ -84,7 +84,7 @@ Then, review `CHANGELOG.md`, change anything that needs to be adjusted and save 
 Run this in the project's folder to add the modified `package.json` and `CHANGELOG.md` files.
 
 ```sh
-git add -u
+git add -p
 ```
 
 There's no need to commit it because the next step will do it.
@@ -99,7 +99,19 @@ To perform the release, run (in the released project's folder):
 yarn version --patch # or --minor, or --major, or --new-version
 ```
 
-If you want to do a pre-release simply use the standard pre-release semver notation (something like `10.0.0-alpha.1`) as the version argument and `liferay-js-publish` will take care of releasing the version with the `prerelease` [npm dist-tag](https://docs.npmjs.com/cli/dist-tag).
+If you want to do a pre-release:
+
+```sh
+yarn version --prepatch # or --preminor, or --premajor
+```
+
+This will cause Yarn to bump the patch, minor, or major versions, and append a `-pre.0` suffix. If you need to follow up with another prerelease, use:
+
+```sh
+yarn version --prerelease
+```
+
+As long as there is a hyphen in the version number, `liferay-js-publish` will take care of releasing the version with the `prerelease` [npm dist-tag](https://docs.npmjs.com/cli/dist-tag).
 
 ### 6. Update the release notes
 


### PR DESCRIPTION
Hey @izaera, figure we might as well make these improvements while how all this works is still fresh in our minds. Let me know what you think, especially with respect to use a generic "-pre" prefix for any prerelease.

---

Given our experience today cutting releases of v10 and v9.5.1, we spent some time looking at the effects of `.yarnrc` files, dist tags, and the behavior of `yarn version` with various different flags:

https://github.com/liferay/liferay-js-themes-toolkit/issues/473

Armed with that knowledge, I think we should make some updates to the documentation here:

- Make it clear that `yarn changelog` must run from a *package* directory, not from the top level ("project" is ambiguous; is it the repo, or a package?).
- Drop "project-name" from version number because liferay-changelog-generator will grab it from .yarnrc directly, since [this PR](https://github.com/liferay/liferay-npm-tools/pull/430).
- Provide details on version number format for prereleases.
- Switch a `git add -u` for a `git add -p`, because it is safer and provides another chance to catch mistakes.
- Document use of `--prepatch` and friends: I suggest we make this the "blessed" way to cut prereleases to avoid possible human errors.
- Fix typo ("google" -> "Google")

Note that the recommendation to use `--prepatch` etc and standardize on a prefix-id of "pre" (ie. making v1.2.3-pre.0) requires us to set a default `--preid` in a .yarnrc file. I think that always using the same "pre" id in this way makes it less likely that we'll screw up a release, and the cost of losing the distinction between "alpha", "beta" etc prereleases is a worthwhile sacrifice. We never really want customers using prereleases anyway; they are almost always used for internal testing only.

We can do this in a single root-level .yarnrc because yarn will walk up the tree looking for files, merging them. I tested this:

- When you cut a normal release (eg `yarn version --patch` etc), the `--preid` is ignored.
- When you cut a prerelease (eg. `yarn version --prepatch` etc), the `--preid` applies automatically.
- `yarn version --prerelease` does what it says in the CONTRIBUTING.md 😂

Docs: https://classic.yarnpkg.com/en/docs/cli/version