### PR TITLE
docs: fix incomplete release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ git grep 9.0.0-alpha.0
 
 Run `yarn changelog --version=v$VERSION`.
 
-### 4. Send a release PR
+### 4. Update release number and tag commit
 
 ```sh
 # See the tests pass locally:
@@ -79,6 +79,8 @@ yarn ci
 # Prepare and push final commit:
 git add -A
 git commit -m "chore: prepare $VERSION release"
+git tag v$VERSION -m v$VERSION
+git push upstream v$VERSION
 git push upstream 9.x
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,7 @@ yarn ci
 git add -A
 git commit -m "chore: prepare $VERSION release"
 git tag v$VERSION -m v$VERSION
-git push upstream v$VERSION
-git push upstream 9.x
+git push upstream 9.x --follow-tags
 ```
 
 ### 5. Update the release notes


### PR DESCRIPTION
We were missing the tag because it was kind of hidden inside the next step, which we removed in the previous PR because it wasn't needed any more.

Note that I have added a command to push the exact tag directly to upstream. 

I tried in v9.5.1 release doing `git push upstream 9.x --follow-tags` to make everything in one step but only managed to:

1) Push a stale `generator-liferay-theme/vv10.0.0-alpha.1` that I had in local (I have fixed the disaster upstream; no need to worry).
2) Don't get the `v9.5.1` tag pushed upstream

:shrug: 

Thus, I decided that pushing the tag explicitly is safer for the future...

**Doubt: I'm unsure if pushing the tag will push the chore commit upstream too. If that was the case, the second push would be superfluous...** :point_left: @wincent Any idea?