### PR TITLE
fix: #482 reverse themes inheritance order

### DIFF
--- a/packages/liferay-theme-tasks/theme/lib/getBaseThemeDependencies.js
+++ b/packages/liferay-theme-tasks/theme/lib/getBaseThemeDependencies.js
@@ -35,9 +35,11 @@ function getBaseThemeDependencies(
 			baseTheme.name
 		);
 
+		dependencies = getBaseThemeDependencies(baseThemePath, dependencies);
+
 		dependencies.push(path.resolve(baseThemePath, 'src', '**', '*'));
 
-		return getBaseThemeDependencies(baseThemePath, dependencies);
+		return dependencies;
 	} else if (baseTheme === 'styled' || baseTheme === 'admin') {
 		dependencies.splice(
 			1,


### PR DESCRIPTION
Inheritance of themes is being applied in reverse order. This PR fixes that.