### PR TITLE
feat: #466 backport batch mode (--config) to v8

### DIFF
--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -413,8 +413,6 @@ module.exports = class extends Generator {
 	_runGulpInit() {
 		const gulp = require('gulp');
 
-		// TODO: remove in v9
-		// See: https://github.com/liferay/liferay-js-themes-toolkit/issues/196
 		process.argv = process.argv.slice(0, 2).concat(['init']);
 
 		require('liferay-theme-tasks').registerTasks({gulp});

--- a/packages/generator-liferay-theme/generators/import/index.js
+++ b/packages/generator-liferay-theme/generators/import/index.js
@@ -56,6 +56,10 @@ module.exports = class extends Base {
 		super.install();
 	}
 
+	_getPromptNamespace() {
+		return 'import';
+	}
+
 	_getPrompts() {
 		const instance = this;
 

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -309,8 +309,6 @@ module.exports = class extends Base {
 	_runGulpInit() {
 		const gulp = require('gulp');
 
-		// TODO: remove in v9
-		// See: https://github.com/liferay/liferay-js-themes-toolkit/issues/196
 		process.argv = process.argv.slice(0, 2).concat(['init']);
 
 		require('liferay-plugin-node-tasks').registerTasks({gulp});

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -165,14 +165,21 @@ module.exports = class extends Base {
 				];
 			}
 
-			new LayoutCreator({
-				after(templateContent) {
-					instance.fs.write(templateDestination, templateContent);
+			new LayoutCreator(
+				Object.assign(
+					{
+						after(templateContent) {
+							instance.fs.write(
+								templateDestination,
+								templateContent
+							);
 
-					done();
-				},
-				...options,
-			});
+							done();
+						},
+					},
+					options
+				)
+			);
 		}
 	}
 

--- a/packages/generator-liferay-theme/generators/layout/index.js
+++ b/packages/generator-liferay-theme/generators/layout/index.js
@@ -12,6 +12,7 @@ const LayoutCreator = require('../../lib/layout_creator');
 const minimist = require('minimist');
 const path = require('path');
 
+const config = require('../../lib/utils/config');
 const Base = require('../app');
 
 module.exports = class extends Base {
@@ -146,14 +147,31 @@ module.exports = class extends Base {
 		if (!this.options['skip-creation']) {
 			const done = this.async();
 
+			const options = {
+				className: this.layoutId,
+				liferayVersion: this.liferayVersion,
+			};
+
+			if (config.batchMode()) {
+				options.rowData = [
+					[
+						{
+							className: 'portlet-column-only',
+							contentClassName: 'portlet-column-content-only',
+							number: 1,
+							size: 12,
+						},
+					],
+				];
+			}
+
 			new LayoutCreator({
 				after(templateContent) {
 					instance.fs.write(templateDestination, templateContent);
 
 					done();
 				},
-				className: this.layoutId,
-				liferayVersion: this.liferayVersion,
+				...options,
 			});
 		}
 	}
@@ -163,18 +181,19 @@ module.exports = class extends Base {
 
 		if (!skipInstall) {
 			this.on('npmInstall:end', () => {
-				const gulp = require('gulp');
-
-				// TODO: remove in v9
-				// See: https://github.com/liferay/liferay-js-themes-toolkit/issues/196
-				process.argv = process.argv.slice(0, 2).concat(['init']);
-
-				require('liferay-plugin-node-tasks').registerTasks({gulp});
-				gulp.start('init');
+				if (config.batchMode()) {
+					this._runBatchGulpInit();
+				} else {
+					this._runGulpInit();
+				}
 			});
 
 			this.installDependencies({bower: false});
 		}
+	}
+
+	_getPromptNamespace() {
+		return 'layout';
 	}
 
 	_getPrompts() {
@@ -199,6 +218,7 @@ module.exports = class extends Base {
 				when: instance._getWhenFn('layoutId', 'id', _.isString),
 			},
 			{
+				default: '7.1',
 				message:
 					'Which version of Liferay is this layout template for?',
 				name: 'liferayVersion',
@@ -224,6 +244,70 @@ module.exports = class extends Base {
 		this.thumbnailFilename = _.snakeCase(layoutId) + '.png';
 
 		this._setPackageVersion(this.liferayVersion);
+	}
+
+	_runBatchGulpInit() {
+		const answers = {
+			deployed: false,
+			pluginName: path.basename(process.cwd()),
+		};
+
+		answers.deploymentStrategy = config.getDefaultAnswer(
+			'init',
+			'deploymentStrategy',
+			'LocalAppServer'
+		);
+		answers.appServerPath = config.getDefaultAnswer(
+			'init',
+			'appServerPath',
+			path.join(path.dirname(process.cwd()), 'tomcat')
+		);
+		answers.deployPath = config.getDefaultAnswer(
+			'init',
+			'deployPath',
+			path.join(answers.appServerPath, '..', 'deploy')
+		);
+		answers.url = config.getDefaultAnswer(
+			'init',
+			'url',
+			'http://localhost:8080'
+		);
+
+		if (answers.deploymentStrategy === 'DockerContainer') {
+			answers.dockerContainerName = config.getDefaultAnswer(
+				'init',
+				'dockerContainerName',
+				'liferay_portal_1'
+			);
+
+			answers.appServerPathPlugin = path.posix.join(
+				answers.appServerPath,
+				'webapps',
+				answers.pluginName
+			);
+		} else {
+			answers.appServerPathPlugin = path.join(
+				answers.appServerPath,
+				'webapps',
+				answers.pluginName
+			);
+		}
+
+		fs.writeFileSync(
+			'liferay-plugin.json',
+			JSON.stringify({LiferayPlugin: answers}, null, 2)
+		);
+	}
+
+	_runGulpInit() {
+		const gulp = require('gulp');
+
+		// TODO: remove in v9
+		// See: https://github.com/liferay/liferay-js-themes-toolkit/issues/196
+		process.argv = process.argv.slice(0, 2).concat(['init']);
+
+		require('liferay-plugin-node-tasks').registerTasks({gulp});
+		gulp.start('init');
 	}
 
 	_setArgv() {

--- a/packages/generator-liferay-theme/generators/themelet/index.js
+++ b/packages/generator-liferay-theme/generators/themelet/index.js
@@ -69,6 +69,10 @@ module.exports = class extends Base {
 		// No-op.
 	}
 
+	_getPromptNamespace() {
+		return 'themelet';
+	}
+
 	_getPrompts() {
 		const instance = this;
 

--- a/packages/generator-liferay-theme/lib/utils/config.js
+++ b/packages/generator-liferay-theme/lib/utils/config.js
@@ -1,17 +1,19 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
  * SPDX-License-Identifier: MIT
  */
+
+'use strict';
 
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 
-let config = {
-	...safeReadJsonSync(
-		path.join(os.homedir(), '.generator-liferay-theme.json')
-	),
-};
+let config = Object.assign(
+	{},
+	safeReadJsonSync(path.join(os.homedir(), '.generator-liferay-theme.json'))
+);
 
 process.argv.forEach((arg, index) => {
 	if (arg === '--config') {

--- a/packages/generator-liferay-theme/lib/utils/config.js
+++ b/packages/generator-liferay-theme/lib/utils/config.js
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+
+let config = {
+	...safeReadJsonSync(
+		path.join(os.homedir(), '.generator-liferay-theme.json')
+	),
+};
+
+process.argv.forEach((arg, index) => {
+	if (arg === '--config') {
+		config = fs.readJsonSync(process.argv[index + 1]);
+	}
+});
+
+/**
+ * Whether to run in batch mode (with no interaction with the user)
+ * @return {boolean} true if all prompts must be answered with default values
+ */
+function batchMode() {
+	if (config.batchMode === undefined) {
+		return false;
+	}
+
+	return config.batchMode;
+}
+
+/**
+ * Get the default answer value for a given prompt.
+ * @param  {string} namespace unique string identifying the calling context
+ * @param  {string} question name of property identifying the question
+ * @param  {*} defaultDefault default value is nothing is configured
+ * @return {*} the default value for the answer
+ */
+function getDefaultAnswer(namespace, question, defaultDefault = undefined) {
+	// Return defaultDefault if no answers section
+	if (config.answers === undefined) {
+		return defaultDefault;
+	}
+
+	let value;
+
+	// Try to get value from specific namespace section
+	if (config.answers[namespace] !== undefined) {
+		value = config.answers[namespace][question];
+	}
+
+	// If not found in specific namespace section, try to get value from *
+	if (value === undefined) {
+		if (config.answers['*'] !== undefined) {
+			value = config.answers['*'][question];
+		}
+	}
+
+	// If not found in any section return defaultDefault
+	if (value === undefined) {
+		return defaultDefault;
+	}
+
+	// If found, return the configured value
+	return value;
+}
+
+/**
+ * Reads a JSON file returning an empty object if the file does not exist.
+ * @param {string} path
+ * @return {object}
+ */
+function safeReadJsonSync(path) {
+	try {
+		return fs.readJsonSync(path);
+	} catch (err) {
+		if (err.code !== 'ENOENT') {
+			throw err;
+		}
+		return {};
+	}
+}
+
+module.exports = {
+	batchMode,
+	getDefaultAnswer,
+};

--- a/packages/generator-liferay-theme/lib/utils/promptWithConfig.js
+++ b/packages/generator-liferay-theme/lib/utils/promptWithConfig.js
@@ -1,7 +1,10 @@
 /**
- * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
  * SPDX-License-Identifier: MIT
  */
+
+'use strict';
 
 const config = require('./config');
 

--- a/packages/generator-liferay-theme/lib/utils/promptWithConfig.js
+++ b/packages/generator-liferay-theme/lib/utils/promptWithConfig.js
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const config = require('./config');
+
+/**
+ * A function to process prompts as specified in the configuration file.
+ * @param  {Generator} generator a Yeoman generator
+ * @param {string} namespace the generator namespace as defined in
+ * 					config.getDefaultAnswer()
+ * @param  {Array} prompts a Yeoman prompts array
+ * @return {object} the set of answers
+ */
+async function promptWithConfig(generator, namespace, prompts) {
+	if (Array.isArray(namespace)) {
+		prompts = namespace;
+		namespace = generator.namespace;
+	}
+
+	// Tweak defaults with config values
+	prompts = prompts.map(prompt => {
+		let defaultDefault = undefined;
+
+		if (prompt.default !== undefined) {
+			defaultDefault = prompt.default;
+		}
+
+		prompt.default = config.getDefaultAnswer(
+			namespace,
+			prompt.name,
+			defaultDefault
+		);
+
+		return prompt;
+	});
+
+	// Decide wether to run in batch or interactive mode
+	if (config.batchMode()) {
+		return prompts.reduce((answers, prompt) => {
+			let val = prompt.default;
+
+			if (typeof val === 'function') {
+				val = val(answers);
+			}
+
+			answers[prompt.name] = val;
+
+			return answers;
+		}, {});
+	} else {
+		return await generator.prompt(prompts);
+	}
+}
+
+module.exports = promptWithConfig;


### PR DESCRIPTION
I have cherry-picked the `promptWithConfig` method from v10 and adapted it to v8. It mostly resembles the same code in v10 but it's a bit different due to the refactors I did in v10.

I have tested the `--config` option manually and compared its output to that of the interactive generator. All seems right. 

However, because this will be tested by the blade team when using it, I have not been very exhaustive in my tests. The plan is releasing an alpha version and then, when the blade team gives the OK, release the final minor version upgrade.