### PR TITLE
fix: #445 gulp init failure

### DIFF
--- a/packages/generator-liferay-theme/generators/facet-theme/index.js
+++ b/packages/generator-liferay-theme/generators/facet-theme/index.js
@@ -80,7 +80,7 @@ module.exports = class extends Generator {
 	}
 
 	end() {
-		runGulpInit();
+		runGulpInit('theme');
 	}
 
 	_getDevDependencies() {

--- a/packages/generator-liferay-theme/generators/layout/standalone-layout.js
+++ b/packages/generator-liferay-theme/generators/layout/standalone-layout.js
@@ -66,7 +66,7 @@ module.exports = class extends Generator {
 	}
 
 	end() {
-		runGulpInit();
+		runGulpInit('plugin');
 	}
 
 	_getDevDependencies() {

--- a/packages/generator-liferay-theme/lib/util.js
+++ b/packages/generator-liferay-theme/lib/util.js
@@ -60,8 +60,10 @@ async function promptWithQA(generator, prompts) {
 
 /**
  * Run `gulp init` after successful creation of a project.
+ *
+ * @param {'plugin' | 'theme'} registerTasksModule
  */
-function runGulpInit() {
+function runGulpInit(registerTasksModule) {
 	print(
 		'\n',
 		success`
@@ -85,7 +87,22 @@ function runGulpInit() {
 	);
 
 	// We cannot load this before the project is created because it crashes
-	const liferayThemeTasks = require('liferay-theme-tasks');
+	let liferayThemeTasks;
+
+	switch (registerTasksModule) {
+		case 'plugin':
+			liferayThemeTasks = require('liferay-theme-tasks/plugin');
+			break;
+
+		case 'theme':
+			liferayThemeTasks = require('liferay-theme-tasks');
+			break;
+
+		default:
+			throw new Error(
+				`Invalid registerTasksModule parameter: ${registerTasksModule}`
+			);
+	}
 
 	liferayThemeTasks.registerTasks({gulp});
 


### PR DESCRIPTION
`gulp init` for layout projects was running the `liferay-theme-tasks` associated to themes. This caused the deployment directory to be written in `liferay-theme.json` instead of `liferay-plugin.json` making `gulp deploy` fail later.

Of course, the fix has been tested. Following the steps described in the issue.