### PR TITLE
fix: #495 support yarn workspaces

### DIFF
--- a/packages/liferay-theme-tasks/lib/project/index.js
+++ b/packages/liferay-theme-tasks/lib/project/index.js
@@ -5,6 +5,9 @@
 
 const crypto = require('crypto');
 const fs = require('fs-extra');
+const {
+	default: FilePath,
+} = require('liferay-npm-build-tools-common/lib/file-path');
 const _ = require('lodash');
 const path = require('path');
 
@@ -61,6 +64,10 @@ class Project {
 
 	get watching() {
 		return this._watching;
+	}
+
+	get workspaceDir() {
+		return this._workspaceDir;
 	}
 
 	/**
@@ -134,6 +141,23 @@ class Project {
 		this._pkgJsonPath = path.join(this.dir, 'package.json');
 		this._pkgJson = fs.readJSONSync(this._pkgJsonPath);
 		this._themeConfig = new ThemeConfig(this);
+		this._workspaceDir = this._findWorkspaceDir(projectDir);
+	}
+
+	_findWorkspaceDir(dir) {
+		dir = path.resolve(dir);
+
+		if (fs.existsSync(path.join(dir, 'yarn.lock'))) {
+			return new FilePath(dir);
+		}
+
+		const parentDir = path.dirname(dir);
+
+		if (parentDir === dir) {
+			return undefined;
+		}
+
+		return this._findWorkspaceDir(parentDir);
 	}
 
 	_reload() {

--- a/packages/liferay-theme-tasks/theme/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/theme/tasks/build/compile-css.js
@@ -159,6 +159,10 @@ function getSassIncludePaths() {
 		includePaths.push(themeNodeModules);
 	}
 
+	if (project.workspaceDir) {
+		includePaths.push(project.workspaceDir.join('node_modules').asNative);
+	}
+
 	return includePaths;
 }
 


### PR DESCRIPTION
Support yarn workpaces in font-awesome enabled projects by simply adding the
workspace's node_modules folder to the SASS include paths.