### PR TITLE
fix(tasks): actually extend local themelets (#499)

### DIFF
--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -187,15 +187,21 @@ it('_afterPromptThemelets should remove unchecked themelets from package.json an
 		),
 	};
 
+	const unreducedThemelets = {
+		'themelet-3': themeletDependencies['themelet-3'],
+	};
+
 	expect(
 		lfrThemeConfig.setConfig.calledWith({
 			themeletDependencies: reducedThemelets,
 		})
 	).toBe(true);
 
-	expect(prototype._saveDependencies.calledWith(reducedThemelets)).toBe(true);
+	expect(prototype._saveDependencies.calledWith(unreducedThemelets)).toBe(
+		true
+	);
 
-	expect(prototype._installDependencies.calledWith(reducedThemelets)).toBe(
+	expect(prototype._installDependencies.calledWith(unreducedThemelets)).toBe(
 		true
 	);
 

--- a/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
+++ b/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js
@@ -91,27 +91,18 @@ class ExtendPrompt {
 	}
 
 	_afterPromptThemelets(answers) {
-		const modulePackages = answers.modules;
 		const themeletDependencies =
 			this.themeConfig.themeletDependencies || {};
 
-		const reducedThemelets = _.reduce(
-			answers.addedThemelets,
-			(result, item) => {
-				result[item] = this._reducePkgData(modulePackages[item]);
-
-				return result;
-			},
-			themeletDependencies
+		const reducedThemelets = this._reduceThemelets(
+			answers,
+			themeletDependencies,
+			item => this._reducePkgData(item)
 		);
 
 		const removedThemelets = answers.removedThemelets;
 
 		if (removedThemelets) {
-			_.forEach(removedThemelets, function(item) {
-				delete reducedThemelets[item];
-			});
-
 			lfrThemeConfig.removeDependencies(removedThemelets);
 		}
 
@@ -119,10 +110,12 @@ class ExtendPrompt {
 			themeletDependencies: reducedThemelets,
 		});
 
-		this._saveDependencies(reducedThemelets);
+		const dependencies = this._reduceThemelets(answers);
+
+		this._saveDependencies(dependencies);
 
 		if (answers.addedThemelets.length) {
-			this._installDependencies(reducedThemelets, () => this.done());
+			this._installDependencies(dependencies, () => this.done());
 		} else {
 			this.done();
 		}
@@ -346,6 +339,32 @@ class ExtendPrompt {
 		}
 
 		return pkg;
+	}
+
+	_reduceThemelets(answers, accumulator, reduceFunction) {
+		const modulePackages = answers.modules;
+		const reduceAccumulator = accumulator || {};
+		const reduce = reduceFunction || (item => item);
+
+		const reducedThemelets = _.reduce(
+			answers.addedThemelets,
+			(result, item) => {
+				result[item] = reduce(modulePackages[item]);
+
+				return result;
+			},
+			reduceAccumulator
+		);
+
+		const removedThemelets = answers.removedThemelets;
+
+		if (removedThemelets) {
+			_.forEach(removedThemelets, item => {
+				delete reducedThemelets[item];
+			});
+		}
+
+		return reducedThemelets;
 	}
 
 	_saveDependencies(updatedData) {


### PR DESCRIPTION
As described in the related issue<sup>[1]</sup>, we have some fragile code in here that uses `__filePath__` property to tag local installs. That is, if we extend a "foo-themelet", it will normally come from an NPM package of the same name, but users can choose to extend a themelet from some local path instead (eg. "~/themelets/my-fancy-themelet"), and in those cases we will use this `__filePath__` property to pass along metadata between the Yeoman prompt and the tasks which actually do the work.

We "reduce" package information that comes in from the Yeoman prompt ("reduce" is a terrible name for it; what it means is we strip out fields that we don't want to be written into the package.json), one aspect of which is rewriting `__filePath__` to `path`.

And then, when we install packages, we need to use the pre-reduced data, not the reduced data, otherwise we end up installing non-local copies.

This was working fine for extending themes and themelets in 9.x, and for extending themes and themelets in 10.x (master), but on the 8.x branch it was only wired up correctly for themes, not for themelets.

So, in the interests of preventing the branches from drifting too far apart, I have taken exactly the same approach in this commit for 8.x as we took in 9.x<sup>[2]</sup> and 10.x (master)<sup>[3]</sup>.

Test plan:

1.  With this version of the toolkit installed, run `yo liferay-theme`.

2.  Create a theme, "test" for 7.1, with deployment method "other".

3.  Somewhere else, `git clone https://github.com/lgdd/sign-in-modal-themelet`, and run `npm link` to make it globally visible as a local install.

4.  Back in the theme, `node_modules/.bin/gulp extend` and choose "Themelet" and pick the sign-in-modal-themelet.

5.  See that the package-lock.json refers to the local version of the themelet and makes no reference to the NPM registry:

    ```
    "sign-in-modal-themelet": {
        "version": "file:../../../../../../../../Users/greghurrell/n/lib/node_modules/sign-in-modal-themelet"
    },
    ```

6.  See that the package.json refers only to the local copy of the themelet as a dependency:

    ```
    "dependencies": {
        "sign-in-modal-themelet": "file:../../../../../../../../Users/greghurrell/n/lib/node_modules/sign-in-modal-themelet"
    }
    ```

    And that the Liferay-specific metadata shows the correct path:

    ```
    "themeletDependencies": {
        "sign-in-modal-themelet": {
            "liferayTheme": {
                "screenshot": "",
                "themelet": true,
                "version": "*"
            },
            "name": "sign-in-modal-themelet",
            "version": "1.0.2",
            "path": "/Users/greghurrell/n/lib/node_modules/sign-in-modal-themelet"
        }
     }
     ```

Also, run tests (which are totally reliant on mocks, so the tests aren't super robust, but they are what they are...).

Closes: https://github.com/liferay/liferay-js-themes-toolkit/issues/499

[1]: https://github.com/liferay/liferay-js-themes-toolkit/issues/499#issuecomment-667969471
[2]: https://github.com/liferay/liferay-js-themes-toolkit/blob/dd3234ef391caba559f6b8578a514db56e07feae/packages/liferay-theme-tasks/lib/prompts/extend_prompt.js#L343-L367
[3]: https://github.com/liferay/liferay-js-themes-toolkit/blob/cefa75c9c64970d3e85530b1b2f1e33adcc49a64/packages/liferay-theme-tasks/theme/prompts/extend_prompt.js#L337-L361