### PR TITLE
chore: don't tag theme-deps packages as "maintenance"

### DIFF
--- a/packages/liferay-theme-deps-7.0/.yarnrc
+++ b/packages/liferay-theme-deps-7.0/.yarnrc
@@ -1,0 +1,1 @@
+--publish.tag latest

--- a/packages/liferay-theme-deps-7.1/.yarnrc
+++ b/packages/liferay-theme-deps-7.1/.yarnrc
@@ -1,0 +1,1 @@
+--publish.tag latest


### PR DESCRIPTION
We have a .yarnrc at the top level to stop 8.x releases from getting the "latest" tag in NPM (likewise on the 9.x branch; we only want 10.x — ie. master — to get the "latest" tags).

But for the two "theme-deps" packages, it's fine for them to have a "latest" tag. Otherwise people will keep getting 8.1.2, which is the last version we released with a latest tag, and never get anything newer.

Not a big deal, of course, because there are no real changes after 8.1.2 anyway, but it still seems desirable that we don't have an NPM versions page that looks like this:

- 8.1.2 ... latest
- 8.2.2 ... maintenance

I'll manually get rid of the maintenance tags on these packages using:

    npm dist-tag rm liferay-theme-deps-7.0 maintenance
    npm dist-tag rm liferay-theme-deps-7.1 maintenance

And make sure the packages I just released have the tag with:

    npm dist-tag add liferay-theme-deps-7.0@8.2.2 latest
    npm dist-tag add liferay-theme-deps-7.1@8.2.2 latest

Note that we don't have to worry about collisions with the 9.x or 10.x (master) series because those don't have these two packages any more.

Test plan: Can't really test this fully without doing a release, but I did a partial test run up to the point where Yarn asks me for a OTP token, at which point I aborted. The `--verbose` output shows that it does find the config files, at least:

```
verbose 0.264 Found configuration file "/Users/greghurrell/.npmrc".
verbose 0.266 Found configuration file "/Users/greghurrell/.npmrc".
verbose 0.27 Found configuration file "/Users/greghurrell/code/liferay-js-themes-toolkit/packages/liferay-theme-deps-7.1/.yarnrc".
verbose 0.271 Found configuration file "/Users/greghurrell/.yarnrc".
verbose 0.271 Found configuration file "/Users/greghurrell/code/liferay-js-themes-toolkit/packages/liferay-theme-deps-7.1/.yarnrc".
verbose 0.272 Found configuration file "/Users/greghurrell/code/liferay-js-themes-toolkit/.yarnrc".
verbose 0.274 Found configuration file "/Users/greghurrell/.yarnrc".
```

I don't know why the messages are being repeated (probably some internal forking leading to multiple yarn processes to be spawned) but you can at least see there that it finds the package-local `.yarnrc` before finding the ones in the ancestor directories; I believe/hope that the most-local file will take precedence at release time.