### PR TITLE
fix: Liferay Theme Tasks update versions for liferay-frontend-theme-s…

### DIFF
--- a/packages/liferay-theme-tasks/lib/devDependencies.js
+++ b/packages/liferay-theme-tasks/lib/devDependencies.js
@@ -57,8 +57,8 @@ module.exports = {
 				'compass-mixins': strict('0.12.10'),
 				gulp: gulpVersion,
 				'liferay-frontend-common-css': strict('1.0.4'),
-				'liferay-frontend-theme-styled': strict('5.0.0'),
-				'liferay-frontend-theme-unstyled': strict('5.0.0'),
+				'liferay-frontend-theme-styled': strict('5.0.12'),
+				'liferay-frontend-theme-unstyled': strict('5.0.16'),
 				'liferay-theme-tasks': themeTasksVersion,
 			},
 			optional: {


### PR DESCRIPTION
…tyled 5.0.13 and liferay-frontend-theme-unstyled 5.0.17 to match 7.3 GA5

I'm not sure these are actually the right version numbers for 7.3 GA5. The commit message `artifact:ignore frontend-theme-styled 5.0.12 prep next` confuses me. Is unstyled actually `5.0.16` and styled `5.0.12` for GA5?
```
'liferay-frontend-theme-styled': strict('5.0.13'),
'liferay-frontend-theme-unstyled': strict('5.0.17'),
```
I took it from:
_unstyled_
https://github.com/liferay/liferay-portal/blob/6d28f4266948e7b0eeb14c3e8d16b3d81e02e8bb/modules/apps/frontend-theme/frontend-theme-unstyled/package.json
_styled_
https://github.com/liferay/liferay-portal/blob/6d28f4266948e7b0eeb14c3e8d16b3d81e02e8bb/modules/apps/frontend-theme/frontend-theme-styled/package.json

I also noticed `'liferay-frontend-common-css': strict('1.0.4')`. It seems like that package name got changed to `liferay-frontend-css-common` some time ago? See https://github.com/liferay/liferay-portal/tree/6d28f4266948e7b0eeb14c3e8d16b3d81e02e8bb/modules/apps/frontend-css/frontend-css-common.