### PR TITLE
fix: [TS] LPS-121779 race condition on liferay-theme-tasks gulp watch task

### DIFF
--- a/packages/liferay-theme-tasks/theme/tasks/watch.js
+++ b/packages/liferay-theme-tasks/theme/tasks/watch.js
@@ -305,8 +305,6 @@ module.exports = function() {
 
 			const taskArray = getBuildTaskArray(resourceDir);
 
-			taskArray.push(clearChangedFile);
-
 			runSequence(...taskArray);
 		});
 	}


### PR DESCRIPTION
LPS-121779 Fix race condition on liferay-theme-tasks gulp watch task 'Cannot read property 'path' of undefined' when changes saved in short time, multiple times.