### PR TITLE
docs(8.x): add migration notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> :warning: The contents of this branch have been migrated [to the `liferay/liferay-frontend-projects` monorepo](https://github.com/liferay/liferay-frontend-projects) and more specifically to the [to the `maintenance/projects/js-themes-toolkit-v8-x` directory](https://github.com/liferay/liferay-frontend-projects/tree/master/maintenance/projects/js-themes-toolkit-v8-x). Development will continue there, and this repo will be archived (ie. switched to read-only mode).
+
+---
+
 # liferay-js-themes-toolkit
 
 ## Overview


### PR DESCRIPTION
This is the 8.x equivalent to [the 10.x](https://github.com/liferay/liferay-js-themes-toolkit/pull/538) and [9.x](https://github.com/liferay/liferay-js-themes-toolkit/pull/539) changes.